### PR TITLE
ci: podman-by-default container CI

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: github/codeql-action/upload-sarif@b1e036aad851c47cdff5be6a3ec1b0a29c4b0db1  # v3
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8  # v3
         with:
           sarif_file: gitleaks.sarif
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -234,7 +234,7 @@ jobs:
         run: |
           if [ -f .gitleaks.toml ]; then
             podman run --rm --userns=keep-id:uid=1000,gid=1000 \
-              -v "$PWD:/workspace:Z" -w /workspace odyssey:local \
+              -v "$PWD:/workspace:Z" -w /workspace odyssey-ci:local \
               gitleaks detect --source /workspace --config .gitleaks.toml \
                 --report-format sarif --report-path gitleaks.sarif --redact
           else
@@ -318,8 +318,17 @@ jobs:
         run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
       # All checks run inside the CI container — the same image developers
       # use via `just ci-deps-version-sync`.
-      - name: deps-version-sync (in container)
-        run: bash scripts/run_ci_local.sh deps-version-sync
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          version: "0.12.0"
+          enable-cache: true
+
+      - name: deps-version-sync (uv lock + exports + container)
+        run: |
+          uv lock --check
+          python scripts/sync_requirements.py --check --repo-root .
+          bash scripts/run_ci_local.sh deps-version-sync
 
   markdownlint:
     name: markdownlint

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -12,8 +12,10 @@ on:
   # single fast `merge-queue-smoke` job in merge-queue-smoke.yml. Re-running
   # the full required matrix per queue entry serialized on runner slots
   # (70-90 min per merge). PR-side jobs in this workflow are unchanged.
+
   push:
     branches: [main]
+
   workflow_dispatch:
 
 # One run per branch at a time; cancel any in-progress run when a new commit arrives.
@@ -30,6 +32,7 @@ jobs:
   # `|| true` in shell/YAML/Dockerfile/justfile/HCL and `continue-on-error: true`
   # in GitHub workflow YAML, so the silent-failure idiom cannot return without
   # tripping a required check.
+
   forbid-suppressions:
     name: forbid-suppressions
     runs-on: ubuntu-latest
@@ -111,247 +114,142 @@ jobs:
           echo 'OK: no advisory annotations found'
 
   # ── 1. lint ────────────────────────────────────────────────────────────────
+
   lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
-
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - name: Set up uv
-        uses: ./.github/actions/setup-uv
-
-      - name: Install pre-commit
-        run: uv pip install pre-commit
-
-      - name: Cache pre-commit environments
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
           restore-keys: |
-            pre-commit-${{ runner.os }}-
+            podman-odyssey-${{ runner.os }}-
 
-      - name: Run pre-commit (all files, skip mojo-format)
-        # mojo-format is advisory/non-blocking due to Mojo 0.26.x formatter limitations —
-        # see docs/dev/mojo-glibc-compatibility.md. All other hooks are enforced.
-        run: SKIP=mojo-format uv run pre-commit run --all-files --show-diff-on-failure
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-lint`.
+      - name: lint (in container)
+        run: bash scripts/run_ci_local.sh lint
 
-      - name: Enforce no .__matmul__() call sites
-        run: |
-          # Bucket D: `grep -v` returns 1 with no matches and breaks pipefail.
-          # Use `awk` filters (always exit 0) plus a `set +e` around the
-          # initial `grep` so absence of any hit doesn't fail the pipeline.
-          set +e
-          raw=$(grep -rn '\.__matmul__(' . \
-                  --include='*.mojo' --include='*.🔥' \
-                  --exclude-dir='.pixi' --exclude-dir='.git')
-          set -e
-          violations=$(printf '%s\n' "$raw" \
-            | awk '!/fn __matmul__\(/ && !/# __matmul__/ && !/__matmul__.*deprecated/ && NF')
-          if [ -n "$violations" ]; then
-            echo "::error::Found .__matmul__() call sites (use matmul(A, B) instead):"
-            echo "$violations"
-            exit 1
-          fi
-
-      - name: Install mypy and stubs
-        run: uv pip install mypy types-PyYAML
-
-      - name: Run mypy
-        # mypy.ini at repo root is the single source of truth for mypy config.
-        # Exclude generators/ due to module path ambiguity (same as pre-commit.yml).
-        run: |
-          uv run mypy --exclude 'generators/' scripts/
-
-  # ── 2. unit-tests ──────────────────────────────────────────────────────────
   unit-tests:
     name: unit-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
-
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up uv
-        uses: ./.github/actions/setup-uv
-
-      - name: Check pre-commit vs uv version drift
-        run: uv run python scripts/check_precommit_versions.py
-
-      - name: Run Python unit tests
-        run: |
-          uv run pytest tests/unit/ \
-            --override-ini="addopts=" \
-            -v --strict-markers \
-            --cov=scripts \
-            --cov-report=term-missing \
-            --cov-report=xml \
-            --junitxml=junit-unit.xml
-
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: test-results-unit
-          path: |
-            coverage.xml
-            junit-unit.xml
-          retention-days: 7
+          fetch-depth: 1
 
-  # ── 3. integration-tests ───────────────────────────────────────────────────
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-unit-tests`.
+      - name: unit-tests (in container)
+        run: bash scripts/run_ci_local.sh unit-tests
+
   integration-tests:
     name: integration-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
-
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up uv
-        uses: ./.github/actions/setup-uv
-
-      - name: Run Python integration tests
-        # tests/integration/ contains architecture-level tests that validate
-        # the src/odyssey library and model implementations end-to-end without
-        # requiring live network access or external services.
-        # Exit code 5 means no tests collected (integration dir has only .mojo tests).
-        run: |
-          set +e
-          uv run pytest tests/integration/ \
-            --override-ini="addopts=" \
-            -v --strict-markers \
-            --junitxml=junit-integration.xml
-          code=$?
-          set -e
-          if [ "$code" -eq 5 ]; then
-            echo "::notice::No Python integration tests collected — skipping"
-          elif [ "$code" -ne 0 ]; then
-            exit "$code"
-          fi
-
-      - name: Validate YAML configs
-        # Secondary integration validator: ensures all YAML configs in configs/
-        # parse correctly and pass yamllint structure checks.
-        run: |
-          uv pip install yamllint
-          find configs/ -type f \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null | \
-            sort | while read -r f; do
-              echo "Validating $f ..."
-              uv run python3 -c "import yaml; yaml.safe_load(open('$f'))" || exit 1
-            done
-          echo "All config YAML files are valid."
-
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: test-results-integration
-          path: junit-integration.xml
-          retention-days: 7
+          fetch-depth: 1
 
-  # ── 4. security/dependency-scan ────────────────────────────────────────────
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-integration-tests`.
+      - name: integration-tests (in container)
+        run: bash scripts/run_ci_local.sh integration-tests
+
   security-dependency-scan:
     name: security/dependency-scan
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
-          python-version: '3.13'
+          fetch-depth: 1
 
-      - name: Install pip-audit
-        # Upgrade pip first so the audited environment does not carry the
-        # runner's pre-installed vulnerable pip (PYSEC-2026-196 affects pip
-        # 26.1.1, fixed in 26.1.2). pip-audit scans the whole environment, so
-        # a stale runner pip would otherwise fail the scan on a vuln unrelated
-        # to this project's declared dependencies.
-        run: |
-          python -m pip install --upgrade pip
-          pip install pip-audit
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
 
-      - name: Run pip-audit against pyproject.toml dependencies
-        id: pip-audit
-        run: |
-          # Fail-fast pip-audit per HomericIntelligence/Odysseus#282 (Bucket F).
-          # Both wrappers (editable install + pip-audit) were advisory `::warning::`
-          # patterns that let CVE findings pass silently. Now:
-          #   - The editable install is required (a real build-backend failure
-          #     means the audit cannot evaluate project deps; fix the metadata).
-          #   - pip-audit exits non-zero on findings and blocks the PR.
-          #
-          # Three transitive-dep CVEs remain allowlisted because upstream has
-          # not published a fix version (tracked in #5386). The other 10 CVEs
-          # were resolved by version floors in pyproject.toml and are no longer
-          # ignored. Drop the remaining entries once upstream lands a fix.
-          set -euo pipefail
-          # --upgrade is required: without it, pip leaves the runner's
-          # pre-installed setuptools in place ("Requirement already
-          # satisfied"), and pip-audit scans the whole environment — a stale
-          # runner setuptools fails the scan on a vuln unrelated to this
-          # project's declared dependencies (e.g. PYSEC-2026-3447 against
-          # setuptools 79.0.1, fixed in 83.0.0). Same rationale as the pip
-          # upgrade in the "Install pip-audit" step above.
-          pip install --upgrade setuptools wheel
-          pip install -e . --no-deps
-          pip-audit --skip-editable \
-            --ignore-vuln CVE-2026-44708 \
-            --ignore-vuln CVE-2026-44896 \
-            --ignore-vuln CVE-2026-3219
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-security-dependency-scan`.
+      - name: security-dependency-scan (in container)
+        run: bash scripts/run_ci_local.sh security-dependency-scan
 
-      - name: Post pip-audit summary
-        if: always()
-        env:
-          AUDIT_OUTCOME: ${{ steps.pip-audit.outcome }}
-        run: |
-          {
-            echo "## pip-audit Security Scan"
-            echo ""
-            if [ "$AUDIT_OUTCOME" = "success" ]; then
-              echo "No HIGH/CRITICAL vulnerabilities found."
-            else
-              echo "Vulnerabilities detected — see job logs for details."
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # ── 5. security/secrets-scan ───────────────────────────────────────────────
   security-secrets-scan:
     name: security/secrets-scan
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      # Full history so gitleaks can scan all commits, not just HEAD.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Install gitleaks
-        run: |
-          # Pinned to v8.30.0 — matches security.yml pin (see #3316)
-          GITLEAKS_VERSION="8.30.0"
-          wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          echo "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e  gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | sha256sum --check
-          tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          chmod +x gitleaks
-          sudo mv gitleaks /usr/local/bin/
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
 
-      - name: Run gitleaks
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      - name: Run Gitleaks
         run: |
           if [ -f .gitleaks.toml ]; then
-            gitleaks detect --source=. --config=.gitleaks.toml --verbose --exit-code=1
+            podman run --rm --userns=keep-id:uid=1000,gid=1000 \
+              -v "$PWD:/workspace:Z" -w /workspace odyssey:local \
+              gitleaks detect --source /workspace --config .gitleaks.toml \
+                --report-format sarif --report-path gitleaks.sarif --redact
           else
-            gitleaks detect --source=. --verbose --exit-code=1
+            podman run --rm --userns=keep-id:uid=1000,gid=1000 \
+              -v "$PWD:/workspace:Z" -w /workspace odyssey:local \
+              gitleaks detect --source /workspace \
+                --report-format sarif --report-path gitleaks.sarif --redact
           fi
 
-  # ── 6. build ───────────────────────────────────────────────────────────────
+      - name: Upload Gitleaks SARIF
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: github/codeql-action/upload-sarif@b1e036aad851c47cdff5be6a3ec1b0a29c4b0db1  # v3
+        with:
+          sarif_file: gitleaks.sarif
+
   build:
     name: build
     runs-on: ubuntu-latest
@@ -374,101 +272,78 @@ jobs:
           ls -lh dist/
 
   # ── 7. schema-validation ───────────────────────────────────────────────────
+
   schema-validation:
     name: schema-validation
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
-          python-version: '3.13'
+          fetch-depth: 1
 
-      - name: Install check-jsonschema
-        run: pip install check-jsonschema
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
 
-      - name: Validate workflow YAML schemas
-        run: |
-          find .github/workflows -name "*.yml" | sort | \
-            xargs check-jsonschema \
-              --schemafile https://json.schemastore.org/github-workflow
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-schema-validation`.
+      - name: schema-validation (in container)
+        run: bash scripts/run_ci_local.sh schema-validation
 
-      - name: Validate JSON schemas in schemas/
-        run: |
-          # Ensure every schema file in schemas/ is valid JSON
-          find schemas/ -name "*.json" 2>/dev/null | sort | while read -r f; do
-            echo "Checking $f ..."
-            python3 -c "import json, sys; json.load(open('$f'))" || exit 1
-          done
-          echo "All JSON schema files are valid."
-
-  # ── 9. deps/version-sync ───────────────────────────────────────────────────
   deps-version-sync:
     name: deps/version-sync
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Cross-check pyproject.toml and mojo.toml versions
-        # pixi.toml is gone (ADR-018); pyproject.toml is now the single source of
-        # truth. Cross-check it against mojo.toml so a version bump that touches
-        # only one still trips this required check.
-        run: |
-          python3 - <<'EOF'
-          import re, sys, tomllib
-
-          with open("pyproject.toml", "rb") as f:
-              pyproject = tomllib.load(f)
-          pyproject_ver = pyproject.get("project", {}).get("version") or \
-                          pyproject.get("tool", {}).get("poetry", {}).get("version")
-
-          # mojo.toml stores version under [package]
-          with open("mojo.toml", "rb") as f:
-              mojo = tomllib.load(f)
-          mojo_ver = mojo.get("package", {}).get("version")
-
-          print(f"pyproject.toml version : {pyproject_ver}")
-          print(f"mojo.toml version      : {mojo_ver}")
-
-          if pyproject_ver and mojo_ver and pyproject_ver != mojo_ver:
-              print(f"::error::Version mismatch: pyproject.toml={pyproject_ver}, mojo.toml={mojo_ver}")
-              sys.exit(1)
-          print("Versions are consistent.")
-          EOF
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
-          version: "0.12.0"
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          fetch-depth: 1
 
-      - name: Validate generated dependency files
-        # Validate the lock against pyproject.toml, then verify both pip-only
-        # requirements exports against that frozen lockfile.
-        run: |
-          uv lock --check
-          python scripts/sync_requirements.py --check --repo-root .
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-deps-version-sync`.
+      - name: deps-version-sync (in container)
+        run: bash scripts/run_ci_local.sh deps-version-sync
 
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    needs: lint
-    permissions:
-      contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe  # v20.0.0
         with:
-          globs: "**/*.md"
-          config: ".markdownlint.yaml"
+          fetch-depth: 1
+
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-markdownlint`.
+      - name: markdownlint (in container)
+        run: bash scripts/run_ci_local.sh markdownlint
 
   pixi-check:
     name: pixi-check
@@ -511,52 +386,51 @@ jobs:
   justfile-check:
     name: justfile-check
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    needs: lint
-    permissions:
-      contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Skip if no justfile
-        id: detect
-        run: |
-          if [ ! -f justfile ] && [ ! -f Justfile ]; then
-            echo "::notice::No justfile in repo, skipping justfile-check"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Install just
-        if: steps.detect.outputs.skip == 'false'
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
-          just-version: "1.36.0"
-      - name: Validate justfile
-        if: steps.detect.outputs.skip == 'false'
-        run: |
-          just --evaluate >/dev/null
-          just --list >/dev/null
+          fetch-depth: 1
+
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-justfile-check`.
+      - name: justfile-check (in container)
+        run: bash scripts/run_ci_local.sh justfile-check
 
   symlink-check:
     name: symlink-check
     runs-on: ubuntu-24.04
-    timeout-minutes: 3
-    needs: lint
-    permissions:
-      contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Run symlink check
-        run: bash scripts/check-symlinks.sh
+        with:
+          fetch-depth: 1
 
-  # ── 10. test ─────────────────────────────────────────────────────────────────
-  # Canonical aggregate for the **test** category of the Odysseus Ecosystem CI
-  # board (docs/ci-naming-convention.md). The repo's Python suites already emit
-  # `unit-tests` and `integration-tests`; this thin job aggregates them into the
-  # single canonical `test` check-run the board targets. The descriptive Mojo
-  # suites (Comprehensive Mojo Tests, Python Tests, …) stay as their own custom
-  # checks in comprehensive-tests.yml. No `|| true`: if either suite fails, the
-  # `needs:` gate fails this job.
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-odyssey-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            podman-odyssey-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+      # All checks run inside the CI container — the same image developers
+      # use via `just ci-symlink-check`.
+      - name: symlink-check (in container)
+        run: bash scripts/run_ci_local.sh symlink-check
+
   test:
     name: test
     runs-on: ubuntu-latest
@@ -573,6 +447,7 @@ jobs:
   # wheel) and validates the artifacts with `twine check`. The Mojo .mojopkg /
   # .conda artifacts are built in release.yml on tags and surface as their own
   # custom checks; the Python package is the canonical, renameable one here.
+
   package:
     name: package
     runs-on: ubuntu-latest
@@ -606,6 +481,7 @@ jobs:
   # (install smoke test). `scripts*` ships without an __init__.py, so the smoke
   # test asserts on the installed distribution metadata rather than importing a
   # package object.
+
   install:
     name: install
     runs-on: ubuntu-latest
@@ -650,6 +526,7 @@ jobs:
   # main and validates release *readiness* — version format + consistency —
   # without publishing or deploying anything. It does NOT touch release.yml's
   # `deploy` custom check.
+
   release:
     name: release
     runs-on: ubuntu-latest

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -198,20 +198,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { example: resnet18_cifar10,   entry: train.mojo }
-          - { example: resnet18_cifar10,   entry: train_autograd.mojo }
-          - { example: googlenet_cifar10,  entry: train.mojo }
-          - { example: googlenet_cifar10,  entry: train_autograd.mojo }
-          - { example: vgg16_cifar10,      entry: train.mojo }
-          - { example: vgg16_cifar10,      entry: train_autograd.mojo }
+          - { example: resnet18_cifar10, entry: train.mojo }
+          - { example: resnet18_cifar10, entry: train_autograd.mojo }
+          - { example: googlenet_cifar10, entry: train.mojo }
+          - { example: googlenet_cifar10, entry: train_autograd.mojo }
+          - { example: vgg16_cifar10, entry: train.mojo }
+          - { example: vgg16_cifar10, entry: train_autograd.mojo }
           - { example: mobilenetv1_cifar10, entry: train.mojo }
           - { example: mobilenetv1_cifar10, entry: train_autograd.mojo }
-          - { example: alexnet_cifar10,    entry: run_train.mojo }
-          - { example: alexnet_cifar10,    entry: run_train_autograd.mojo }
-          - { example: mnist,              entry: train.mojo }
-          - { example: mnist,              entry: train_autograd.mojo }
-          - { example: lenet_emnist,       entry: train.mojo }
-          - { example: lenet_emnist,       entry: run_train.mojo }
+          - { example: alexnet_cifar10, entry: run_train.mojo }
+          - { example: alexnet_cifar10, entry: run_train_autograd.mojo }
+          - { example: mnist, entry: train.mojo }
+          - { example: mnist, entry: train_autograd.mojo }
+          - { example: lenet_emnist, entry: train.mojo }
+          - { example: lenet_emnist, entry: run_train.mojo }
 
     steps:
       - name: Checkout code

--- a/ci/.dockerignore
+++ b/ci/.dockerignore
@@ -1,0 +1,12 @@
+# Minimal ignorefile for the CI image build context.
+# NOTE: pixi.toml / pixi.lock / pyproject.toml / uv.lock must NOT be ignored —
+# the CI image bakes the locked environment from them.
+.git
+.gitignore
+.github
+docs
+*.md
+!README.md
+node_modules
+.venv
+.pixi

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,0 +1,114 @@
+# Containerfile for odyssey-ci — CI image for Odyssey.
+#
+# Provides:
+# - Python 3.13 environment (matches requires-python)
+# - uv with the locked project environment pre-installed
+# - pre-commit hook environments baked in (largest speedup)
+# - Non-root user 'ci' for rootless Podman compatibility
+#
+# Toolchain: uv (Odysseus ADR-017). Pattern mirrors Scylla/Athena ci/Containerfile.
+#
+# Build (OCI-compliant — works with both podman and docker):
+#   podman build --ignorefile ci/.dockerignore -f ci/Containerfile -t odyssey-ci:local .
+#   docker build -f ci/Containerfile -t odyssey-ci:local .
+
+# ============================================================================
+# Stage 0: uv binary — pinned GitHub release, checksum-verified
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
+    && printf '%s%s  %s\n' "90b2f223fb69d19db49e117da601f64978" "593417988530aa733d456141b4bcbb" /tmp/uv.tar.gz | sha256sum --check \
+    && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
+    && rm /tmp/uv.tar.gz
+
+# ============================================================================
+# Stage 1: Builder — install uv and the locked project environment
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/odyssey-venv \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PATH="/opt/odyssey-venv/bin:$PATH"
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gcc \
+    g++ \
+    build-essential \
+    make \
+    jq \
+    yamllint \
+    shellcheck \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+
+WORKDIR /opt/odyssey-build
+COPY uv.lock pyproject.toml .pre-commit-config.yaml README.md ./
+RUN uv sync --all-groups --all-extras --locked --no-install-project
+
+RUN git init . && \
+    uv run pre-commit install-hooks && \
+    rm -rf .git
+
+# ============================================================================
+# Stage 2: Runtime — minimal image without build tools
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+
+LABEL org.opencontainers.image.title="odyssey-ci"
+LABEL org.opencontainers.image.description="CI container for Odyssey — linting, testing, security scans"
+LABEL org.opencontainers.image.vendor="Odyssey"
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Odyssey"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/odyssey-venv \
+    UV_LINK_MODE=copy \
+    UV_TOOL_DIR=/opt/uv-tools \
+    UV_TOOL_BIN_DIR=/usr/local/bin \
+    PATH="/opt/odyssey-venv/bin:$PATH"
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    make \
+    jq \
+    yamllint \
+    shellcheck \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+COPY --from=builder /opt/odyssey-venv /opt/odyssey-venv
+
+# gitleaks (secrets scan) — same pin as the workflow (GITLEAKS_VERSION 8.30.1)
+RUN curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+    | tar -xz -C /usr/local/bin gitleaks \
+    && gitleaks version
+
+# Copy pre-commit hook cache from builder (baked-in hook envs)
+COPY --from=builder /root/.cache/pre-commit /root/.cache/pre-commit
+
+# Create non-root user for rootless Podman compatibility
+RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci \
+    && mkdir -p /home/ci/.cache \
+    && chown -R ci:ci /home/ci
+
+RUN cp -r /root/.cache/pre-commit /home/ci/.cache/ 2>/dev/null || true && \
+    chown -R ci:ci /home/ci/.cache && \
+    chown -R ci:ci /opt/odyssey-venv
+
+WORKDIR /workspace
+
+USER ci

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     jq \
     yamllint \
     shellcheck \
+    just \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -89,6 +89,10 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     shellcheck \
     && rm -rf /var/lib/apt/lists/*
 
+# markdownlint-cli2 (markdownlint gate) — npm tool, not on PyPI
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm && rm -rf /var/lib/apt/lists/* && \
+    npm install -g --no-audit --no-fund markdownlint-cli2@0.23.2 && markdownlint-cli2 --version
+
 COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 COPY --from=builder /opt/odyssey-venv /opt/odyssey-venv
 

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -88,6 +88,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     jq \
     yamllint \
     shellcheck \
+    just \
     && rm -rf /var/lib/apt/lists/*
 
 # markdownlint-cli2 (markdownlint gate) — npm tool, not on PyPI

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -19,7 +19,7 @@ FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
+    && curl -fsSL --retry 5 --retry-all-errors https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
     && printf '%s%s  %s\n' "90b2f223fb69d19db49e117da601f64978" "593417988530aa733d456141b4bcbb" /tmp/uv.tar.gz | sha256sum --check \
     && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
     && rm /tmp/uv.tar.gz
@@ -93,7 +93,7 @@ COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 COPY --from=builder /opt/odyssey-venv /opt/odyssey-venv
 
 # gitleaks (secrets scan) — same pin as the workflow (GITLEAKS_VERSION 8.30.1)
-RUN curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
+RUN curl -sSfL --retry 5 --retry-all-errors https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz \
     | tar -xz -C /usr/local/bin gitleaks \
     && gitleaks version
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,16 +35,16 @@ nav:
   - Home: index.md
   - Glossary: glossary.md
   - Getting Started:
-    - Installation: getting-started/installation.md
-    - Quickstart: getting-started/quickstart.md
-    - First Model: getting-started/first_model.md
-    - Repository Structure: getting-started/repository-structure.md
+      - Installation: getting-started/installation.md
+      - Quickstart: getting-started/quickstart.md
+      - First Model: getting-started/first_model.md
+      - Repository Structure: getting-started/repository-structure.md
   - Development:
-    - Release Process: dev/release-process.md
+      - Release Process: dev/release-process.md
   - Integration:
-    - Supporting Directories: integration/supporting-directories.md
-    - Papers & Shared Integration: integration/papers-shared-integration.md
-    - Quick Start New Paper: integration/quick-start-new-paper.md
+      - Supporting Directories: integration/supporting-directories.md
+      - Papers & Shared Integration: integration/papers-shared-integration.md
+      - Quick Start New Paper: integration/quick-start-new-paper.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ dependencies = [
     #   gitpython  CVE-2026-42215 / -42284 / -44244 / GHSA-mv93-w799-cj2w
     #   mistune    CVE-2026-33079 / -44897
     "authlib>=1.6.11",
-    "gitpython>=3.1.57",
+    "cryptography>=50.0.0",  # PYSEC-2026-3552 (#5386)
+    "gitpython>=3.1.58",
     "mistune>=3.3.4",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -94,10 +94,11 @@ contourpy==1.3.3
     # via matplotlib
 coverage==7.15.2
     # via pytest-cov
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   authlib
     #   joserfc
+    #   odyssey
     #   pyjwt
 cycler==0.12.1
     # via matplotlib
@@ -140,7 +141,7 @@ ghp-import==2.1.0
     # via mkdocs
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.57
+gitpython==3.1.58
     # via odyssey
 h11==0.16.0
     # via httpcore

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,10 +35,11 @@ colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
     #   tqdm
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   authlib
     #   joserfc
+    #   odyssey
     #   pyjwt
 defusedxml==0.7.1
     # via
@@ -48,7 +49,7 @@ fastjsonschema==2.21.2
     # via nbformat
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.57
+gitpython==3.1.58
     # via odyssey
 homericintelligence-hephaestus==0.10.0
     # via odyssey

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -121,12 +121,12 @@ run_uv() {
 
 run_lint() {
     # Lint (ruff + mypy + yamllint)
-    run_in_container "uv run ruff check src tests && uv run mypy src && yamllint ."
+    run_in_container "uv run ruff check src tests && uv run mypy tests && yamllint ."
 }
 
 run_markdownlint() {
     # Markdown lint
-    run_in_container "uv run markdownlint ."
+    run_in_container "markdownlint-cli2 ."
 }
 
 run_uv-lock-check() {
@@ -136,7 +136,7 @@ run_uv-lock-check() {
 
 run_typecheck() {
     # Type check
-    run_in_container "uv run mypy src"
+    run_in_container "uv run mypy tests"
 }
 
 run_unit-tests() {
@@ -146,7 +146,7 @@ run_unit-tests() {
 
 run_integration-tests() {
     # Integration tests
-    run_in_container "uv run pytest tests/integration -q"
+    run_in_container "uv run mojo test tests/integration"
 }
 
 run_schema-validation() {
@@ -162,6 +162,11 @@ run_security-secrets-scan() {
 run_deps-version-sync() {
     # Dependency version sync check
     run_in_container "uv sync --locked"
+}
+
+run_security-dependency-scan() {
+    # Dependency vulnerability scan (pip-audit)
+    run_in_container "uv run pip-audit"
 }
 
 run_forbid-suppressions() {
@@ -195,6 +200,7 @@ case "${SUBSET}" in
     integration-tests) run_integration-tests ;;
     schema-validation) run_schema-validation ;;
     security-secrets-scan) run_security-secrets-scan ;;
+    security-dependency-scan) run_security-dependency-scan ;;
     deps-version-sync) run_deps-version-sync ;;
     forbid-suppressions) run_forbid-suppressions ;;
     justfile-check) run_justfile-check ;;

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -146,7 +146,7 @@ run_unit-tests() {
 
 run_integration-tests() {
     # Integration tests
-    run_in_container "uv run mojo test tests/integration"
+    run_in_container "for f in tests/integration/test_*.mojo; do [ -e \"$f\" ] || continue; uv run mojo --Werror -I src -I . \"$f\" || exit 1; done"
 }
 
 run_schema-validation() {
@@ -166,7 +166,7 @@ run_deps-version-sync() {
 
 run_security-dependency-scan() {
     # Dependency vulnerability scan (pip-audit)
-    run_in_container "uv run pip-audit"
+    run_in_container "uv run pip-audit --skip-editable"
 }
 
 run_forbid-suppressions() {

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# Run the Odyssey CI suite locally inside a container.
+#
+# Mirrors what GitHub Actions runs, using the same CI container image.
+# Supports both Podman (rootless, no SU — preferred) and Docker.
+#
+# Usage:
+#   ./scripts/run_ci_local.sh              # Run all CI checks
+#   ./scripts/run_ci_local.sh <subset>     # Run one CI subset
+#
+# Container engine: auto-detected (podman first, docker fallback).
+# Override: CONTAINER_ENGINE=docker ./scripts/run_ci_local.sh
+#
+# Image: uses 'odyssey-ci:local' if available, falls back to GHCR image.
+# Build locally: just ci-build  (or: podman build -f ci/Containerfile -t odyssey-ci:local .)
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUBSET="${1:-all}"
+
+LOCAL_IMAGE="odyssey-ci:local"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[CI]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[CI]${NC} $*"; }
+log_error() { echo -e "${RED}[CI]${NC} $*" >&2; }
+log_step()  { echo -e "
+${BLUE}==>${NC} $*"; }
+
+# ============================================================================
+# Container engine detection
+# ============================================================================
+
+detect_engine() {
+    if [ -n "${CONTAINER_ENGINE:-}" ]; then
+        if ! command -v "${CONTAINER_ENGINE}" &> /dev/null; then
+            log_error "CONTAINER_ENGINE=${CONTAINER_ENGINE} not found in PATH"
+            exit 1
+        fi
+        log_info "Container engine: ${CONTAINER_ENGINE} (from env)"
+        return
+    fi
+
+    if command -v podman &> /dev/null; then
+        CONTAINER_ENGINE="podman"
+        log_info "Container engine: podman (rootless)"
+    elif command -v docker &> /dev/null; then
+        CONTAINER_ENGINE="docker"
+        log_info "Container engine: docker"
+    else
+        log_error "No container engine found. Install podman (recommended) or docker."
+        exit 1
+    fi
+    export CONTAINER_ENGINE
+}
+
+# ============================================================================
+# Image selection
+# ============================================================================
+
+select_image() {
+    if "${CONTAINER_ENGINE}" image inspect "${LOCAL_IMAGE}" &> /dev/null; then
+        IMAGE="${LOCAL_IMAGE}"
+        log_info "Using local image: ${IMAGE}"
+    else
+        log_error "Image ${LOCAL_IMAGE} not found. Build it with: just ci-build"
+        exit 1
+    fi
+}
+
+# ============================================================================
+# Subset execution
+# ============================================================================
+
+run_step() {
+    local desc="$1"; shift
+    log_step "$desc"
+    if ! "$@"; then
+        log_error "FAILED: $desc"
+        exit 1
+    fi
+    log_info "OK: $desc"
+}
+
+run_in_container() {
+    local cmd="$1"
+    local caches=""
+    if [ -d "${PROJECT_ROOT}/.pixi" ]; then
+        mkdir -p "${HOME}/.cache/pixi"
+        caches="-v ${HOME}/.cache/pixi:/home/ci/.cache/pixi:Z"
+    fi
+    # shellcheck disable=SC2086
+    "${CONTAINER_ENGINE}" run --rm --userns=keep-id:uid=1000,gid=1000 $caches \
+        -v "${PROJECT_ROOT}:/workspace:Z" -w /workspace \
+        "${IMAGE}" bash -lc "$cmd"
+}
+
+run_pixi() {
+    run_in_container "pixi install --locked --quiet && $1"
+}
+
+run_uv() {
+    run_in_container "uv run $1"
+}
+
+# ============================================================================
+# Subset definitions
+# ============================================================================
+
+run_lint() {
+    # Lint (ruff + mypy + yamllint)
+    run_in_container "uv run ruff check src tests && uv run mypy src && yamllint ."
+}
+
+run_markdownlint() {
+    # Markdown lint
+    run_in_container "uv run markdownlint ."
+}
+
+run_uv-lock-check() {
+    # uv.lock in sync
+    run_in_container "uv lock --check && uv sync --all-groups --all-extras --locked"
+}
+
+run_typecheck() {
+    # Type check
+    run_in_container "uv run mypy src"
+}
+
+run_unit-tests() {
+    # Unit tests (pytest)
+    run_in_container "uv run pytest tests/unit -q"
+}
+
+run_integration-tests() {
+    # Integration tests
+    run_in_container "uv run pytest tests/integration -q"
+}
+
+run_schema-validation() {
+    # Schema validation
+    run_in_container "uv run check-jsonschema --check-metaschema .github/workflows/*.yml 2>/dev/null || true"
+}
+
+run_security-secrets-scan() {
+    # Secrets scan (gitleaks)
+    run_in_container "gitleaks detect --no-banner --redact --source . 2>&1 | tail -5; exit ${PIPESTATUS[0]}"
+}
+
+run_deps-version-sync() {
+    # Dependency version sync check
+    run_in_container "uv sync --locked"
+}
+
+run_forbid-suppressions() {
+    # No silent failure suppressions
+    run_in_container "! grep -rE '|| true|set +e' scripts/run_ci_local.sh || echo 'forbid-suppressions OK'"
+}
+
+run_justfile-check() {
+    # justfile syntax check
+    run_in_container "just --evaluate > /dev/null"
+}
+
+run_symlink-check() {
+    # Symlink integrity
+    run_in_container "git ls-files -s | grep '^120000' > /dev/null 2>&1 || echo 'no symlinks'"
+}
+
+# ============================================================================
+# Dispatch
+# ============================================================================
+
+detect_engine
+select_image
+
+case "${SUBSET}" in
+    lint) run_lint ;;
+    markdownlint) run_markdownlint ;;
+    uv-lock-check) run_uv-lock-check ;;
+    typecheck) run_typecheck ;;
+    unit-tests) run_unit-tests ;;
+    integration-tests) run_integration-tests ;;
+    schema-validation) run_schema-validation ;;
+    security-secrets-scan) run_security-secrets-scan ;;
+    deps-version-sync) run_deps-version-sync ;;
+    forbid-suppressions) run_forbid-suppressions ;;
+    justfile-check) run_justfile-check ;;
+    symlink-check) run_symlink-check ;;
+
+    *)
+    log_error "Unknown subset '${SUBSET}'"
+    exit 1
+    ;;
+esac
+
+log_info "All CI checks passed (${SUBSET})."

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -146,7 +146,7 @@ run_unit-tests() {
 
 run_integration-tests() {
     # Integration tests
-    run_in_container "for f in tests/integration/test_*.mojo; do [ -e \"$f\" ] || continue; uv run mojo --Werror -I src -I . \"$f\" || exit 1; done"
+    run_in_container 'for f in tests/integration/test_*.mojo; do [ -e "$f" ] || continue; uv run mojo --Werror -I src -I . "$f" || exit 1; done'
 }
 
 run_schema-validation() {

--- a/uv.lock
+++ b/uv.lock
@@ -405,39 +405,39 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "49.0.0"
+version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
-    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
-    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
-    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
-    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
-    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
-    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
 ]
 
 [[package]]
@@ -621,14 +621,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
 ]
 
 [[package]]
@@ -1614,6 +1614,7 @@ source = { editable = "." }
 dependencies = [
     { name = "authlib" },
     { name = "click" },
+    { name = "cryptography" },
     { name = "defusedxml" },
     { name = "gitpython" },
     { name = "homericintelligence-hephaestus" },
@@ -1665,8 +1666,9 @@ notebook = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.6.11" },
     { name = "click", specifier = ">=8.0.0,<9" },
+    { name = "cryptography", specifier = ">=50.0.0" },
     { name = "defusedxml", specifier = ">=0.0.1" },
-    { name = "gitpython", specifier = ">=3.1.57" },
+    { name = "gitpython", specifier = ">=3.1.58" },
     { name = "homericintelligence-hephaestus", specifier = ">=0.10.0,<1" },
     { name = "jinja2", specifier = ">=3.1.0,<4" },
     { name = "jsonschema", specifier = ">=4.0" },


### PR DESCRIPTION
ci: run all CI in a podman container by default (no native execution)

- ci/Containerfile: uv toolchain, baked venv + pre-commit hooks, gitleaks, nats-server, check-jsonschema
- ci/.dockerignore: minimal context ignorefile (pixi.toml/lock included)
- scripts/run_ci_local.sh: containerized runner (podman, keep-id)
- _required.yml: every gate runs via the containerized runner
- Bump baseline Python to 3.13