### PR TITLE
fix(scan): harden workflow injection, permissions, and SRI hashes

- 6x run-shell-injection + 1x script-injection (container-publish, docs, release,
  mojo-version-check, benchmark, pr-comment action): moved ${{\\ }} interpolation
  into env: blocks and reference $VAR in run steps / process.env in github-script
- validate-configs.yml: added least-privilege permissions (read-only, contents: read)
- dashboard.html: corrected plotly 2.27.0 SRI sha384 (computed from the CDN artifact)
- notebook/tensor_utils path handling verified against the already-landed safe_path
  guard; 7 py/path-injection alerts confirmed stale (fixed by 08bc38f6, awaiting rescan)
- 8 missing-permissions alerts on 4 deleted workflows confirmed stale (85ab3bce
  consolidated them); CVE dep pins (pyjwt/tornado/msgpack/setuptools) already in source
Verified: YAML parses, actionlint clean, tensor_utils compiles.

### DIFF
--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -20,12 +20,15 @@ runs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
       with:
         github-token: ${{ inputs.github-token }}
+        env:
+          REPORT_FILE: ${{ inputs.report-file }}
+          COMMENT_MARKER: ${{ inputs.comment-marker }}
         script: |
           const fs = require('fs');
 
           try {
-            const report = fs.readFileSync('${{ inputs.report-file }}', 'utf8');
-            const marker = '${{ inputs.comment-marker }}';
+            const report = fs.readFileSync(process.env.REPORT_FILE, 'utf8');
+            const marker = process.env.COMMENT_MARKER;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -18,11 +18,11 @@ runs:
   steps:
     - name: Post or update PR comment
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+      env:
+        REPORT_FILE: ${{ inputs.report-file }}
+        COMMENT_MARKER: ${{ inputs.comment-marker }}
       with:
         github-token: ${{ inputs.github-token }}
-        env:
-          REPORT_FILE: ${{ inputs.report-file }}
-          COMMENT_MARKER: ${{ inputs.comment-marker }}
         script: |
           const fs = require('fs');
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,9 +66,12 @@ jobs:
 
       - name: Check if should run this suite
         id: check-suite
+        env:
+          REQUESTED_SUITE: ${{ github.event.inputs.suite || 'all' }}
+          CURRENT_SUITE: ${{ matrix.benchmark-suite }}
         run: |
-          REQUESTED_SUITE="${{ github.event.inputs.suite || 'all' }}"
-          CURRENT_SUITE="${{ matrix.benchmark-suite }}"
+          REQUESTED_SUITE="$REQUESTED_SUITE"
+          CURRENT_SUITE="$CURRENT_SUITE"
 
           if [ "$REQUESTED_SUITE" = "all" ] || [ "$REQUESTED_SUITE" = "$CURRENT_SUITE" ]; then
             echo "run=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -186,8 +186,10 @@ jobs:
 
       - name: Export image for SBOM
         if: github.event_name != 'pull_request' && matrix.target == 'runtime'
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          podman save -o /tmp/runtime-image.tar "$REGISTRY/$IMAGE_NAME:${{ github.ref_name }}"
+          podman save -o /tmp/runtime-image.tar "$REGISTRY/$IMAGE_NAME:$REF_NAME"
 
       - name: Generate SBOM
         if: github.event_name != 'pull_request' && matrix.target == 'runtime'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -142,12 +142,15 @@ jobs:
 
       - name: Determine validation level
         id: validation-level
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_LEVEL: ${{ github.event.inputs.validation_level }}
         run: |
           # Manual dispatch uses input
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            LEVEL="${{ github.event.inputs.validation_level }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            LEVEL="$INPUT_LEVEL"
           # Weekly schedule (Sunday = day 0) = comprehensive
-          elif [ "${{ github.event_name }}" = "schedule" ]; then
+          elif [ "$EVENT_NAME" = "schedule" ]; then
             DAY_OF_WEEK=$(date +%w)
             if [ "$DAY_OF_WEEK" = "0" ]; then
               LEVEL="comprehensive"

--- a/.github/workflows/mojo-version-check.yml
+++ b/.github/workflows/mojo-version-check.yml
@@ -71,10 +71,14 @@ jobs:
 
       - name: Compare versions
         id: compare
+        env:
+          CURRENT: ${{ steps.current.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+          FORCE: ${{ inputs.force_check }}
         run: |
-          CURRENT="${{ steps.current.outputs.version }}"
-          LATEST="${{ steps.latest.outputs.version }}"
-          FORCE="${{ inputs.force_check }}"
+          CURRENT="$CURRENT"
+          LATEST="$LATEST"
+          FORCE="$FORCE"
 
           echo "Current: $CURRENT"
           echo "Latest: $LATEST"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,12 @@ jobs:
 
       - name: Get version from tag or input
         id: get-version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
           else
             VERSION="${GITHUB_REF#refs/tags/}"
           fi
@@ -91,8 +94,10 @@ jobs:
 
       - name: Determine if pre-release
         id: check-prerelease
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
+          VERSION="$VERSION"
           IS_PRERELEASE="false"
 
           # Check manual input first

--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -2,6 +2,9 @@ name: Validate Configurations
 
 # Also covers: test-agents, script-validation, paper-validation, validate-workflows
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/notebooks/utils/tensor_utils.py
+++ b/notebooks/utils/tensor_utils.py
@@ -4,6 +4,7 @@ Handles serialization/deserialization of tensors for
 Mojo-Python interop.
 """
 
+import ast
 import numpy as np
 from pathlib import Path
 from typing import Tuple, Optional
@@ -166,8 +167,9 @@ def parse_mojo_tensor_output(output: str) -> Optional[np.ndarray]:
         for line in lines:
             line = line.strip()
             if line.startswith("[[") or line.startswith("["):
-                # Try to parse as list
-                tensor_list = eval(line)  # Use ast.literal_eval for safety in production
+                # Try to parse as list. literal_eval only evaluates literals,
+                # so untrusted notebook output cannot execute code.
+                tensor_list = ast.literal_eval(line)
                 return np.array(tensor_list)
         return None
     except Exception:

--- a/scripts/dashboard/templates/dashboard.html
+++ b/scripts/dashboard/templates/dashboard.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ML Odyssey Training Dashboard</title>
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"
+            integrity="sha384-Hl48Kq2HifOWdXEjMsKo6qxqvRLTYqIGbvlENBmkHAxZKIGCXv43H6W1jA671RzC"
+            crossorigin="anonymous"></script>
     <style>
         :root {
             --bg-primary: #1a1a2e;


### PR DESCRIPTION
## Summary
fix(scan): harden workflow injection, permissions, and SRI hashes

- 6x run-shell-injection + 1x script-injection (container-publish, docs, release,
  mojo-version-check, benchmark, pr-comment action): moved ${{\\ }} interpolation
  into env: blocks and reference $VAR in run steps / process.env in github-script
- validate-configs.yml: added least-privilege permissions (read-only, contents: read)
- dashboard.html: corrected plotly 2.27.0 SRI sha384 (computed from the CDN artifact)
- notebook/tensor_utils path handling verified against the already-landed safe_path
  guard; 7 py/path-injection alerts confirmed stale (fixed by 08bc38f6, awaiting rescan)
- 8 missing-permissions alerts on 4 deleted workflows confirmed stale (85ab3bce
  consolidated them); CVE dep pins (pyjwt/tornado/msgpack/setuptools) already in source
Verified: YAML parses, actionlint clean, tensor_utils compiles.

## Validation
- Signed commit (GPG) with DCO sign-off
- Targeted validation run per-repo (unit tests / tsc / actionlint / syntax checks)

Closes nothing (fleet-wide code-scanning alert remediation).