### PR TITLE
ci(workflows): add least-privilege permissions to validate-workflows.yml (#5790)

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,5 +1,8 @@
 name: Validate Workflow Checkout Order
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Closes the last workflow in the repo with no explicit permissions.

## Context

The 12 `actions/missing-workflow-permissions` alerts from #5790 are **already auto-closed** — the latest CodeQL scan of `main` (head `dc0479a8`, after the #5792 merge) re-scanned and closed all 12: 11 referenced workflows restructured into `validate-configs.yml` by #5787 (which carries `permissions: contents: read` at top level), and the 12th pointed at `validate-configs.yml` itself, now covered.

## This change

A quick sweep of `.github/workflows/` found one remaining workflow with **no permissions at any level**: `validate-workflows.yml`. Its job only checks out the repo and runs a read-only Python validation script, so least privilege is:

```yaml
permissions:
  contents: read
```

Matches the fleet standard applied across the other 27 workflows.
