### PR TITLE
fix(cve): pin ubuntu base digest + apt upgrade in runtime stage

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,7 +14,7 @@ FROM ghcr.io/astral-sh/uv:0.12.3@sha256:2d890623d310b57771ce840f0da5eed5fc6d657d
 # ==============================================================================
 # Stage 1: Builder - Install dependencies and build packages
 # ==============================================================================
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS builder
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04@sha256:4fdf0125919d24aec972544669dcd7d6a26a8ad7e6561c73d5549bd6db258ac2 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -71,12 +71,12 @@ COPY --chown=${USER_NAME}:${USER_NAME} pyproject.toml ./
 # ==============================================================================
 # Stage 2: Runtime - Minimal image for running tests/inference
 # ==============================================================================
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS runtime
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04@sha256:4fdf0125919d24aec972544669dcd7d6a26a8ad7e6561c73d5549bd6db258ac2 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install minimal runtime dependencies (as root)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hardens the OS layer of the published Odyssey images (Dockerfile.ci runtime/production stages), mirroring the Keystone #653 playbook.

## What
- Pin `mcr.microsoft.com/mirror/docker/library/ubuntu:24.04` to the 2026-08-17 digest (builder + runtime)
- Add `apt-get upgrade` to the runtime stage (was install-only, so published images shipped stale libgnutls30t64, libc6/libc-bin, libudev1/libsystemd0, tar, libgcrypt20, gpgv)

## Verification
- Fresh base + `apt-get upgrade` scans **0 CRITICAL/HIGH** with trivy 0.58.1
- pyjwt 2.13.0 / tornado 6.5.7 were already fixed in uv.lock by #5794 (stale alert instances clear on the next container-publish scan)

## Notes
- perl-base (4 CRITICAL) has no Ubuntu fix yet (candidate == installed); trivy on this repo is report-only (SARIF upload, no gate)
- The 96 open trivy-container alerts are stale instances from the pre-hardening image; the next publish re-scans and refreshes them
