### PR TITLE
fix(cve): pin system-python setuptools/msgpack in both images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,12 @@ COPY --chown=${USER_NAME}:${USER_NAME} pyproject.toml uv.lock .python-version .p
 # baked in here; the workspace source is bind-mounted at runtime.
 RUN uv sync --locked --no-install-project
 
+# Security pin for the system python3 preinstalled in the ubuntu:24.04 base.
+# trivy flags the base-shipped setuptools 70.3.0 (CVE-2025-47273, CVE-2026-59890)
+# and msgpack 1.1.2 (GHSA-6v7p-g79w-8964). PEP 668 on noble requires
+# --break-system-packages for the distro-managed interpreter.
+RUN if command -v python3 >/dev/null 2>&1; then         python3 -m ensurepip --upgrade --break-system-packages >/dev/null 2>&1;         python3 -m pip install --no-cache-dir --break-system-packages             setuptools==83.0.0 msgpack==1.2.1;     fi
+
 # Ensure pre-commit is available in the uv environment
 RUN uv run pre-commit --version
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -110,6 +110,14 @@ COPY --chown=${USER_NAME}:${USER_NAME} pyproject.toml uv.lock .python-version ./
 # Install runtime dependencies only (incl. Mojo compiler)
 RUN uv sync --locked --no-install-project
 
+# Security pin for the system python3 preinstalled in the ubuntu:24.04 base.
+# trivy flags the base-shipped setuptools 70.3.0 (CVE-2025-47273, CVE-2026-59890)
+# and msgpack 1.1.2 (GHSA-6v7p-g79w-8964). PEP 668 on noble requires
+# --break-system-packages for the distro-managed interpreter. The app venv
+# (UV_PROJECT_ENVIRONMENT) is already pinned to fixed versions via uv.lock;
+# this clears the system-python residual so the published image scans clean.
+RUN if command -v python3 >/dev/null 2>&1; then         python3 -m ensurepip --upgrade --break-system-packages >/dev/null 2>&1;         python3 -m pip install --no-cache-dir --break-system-packages             setuptools==83.0.0 msgpack==1.2.1;     fi
+
 # Copy built artifacts and source
 # /build is the fixed WORKDIR set in builder stage (username-independent)
 COPY --chown=${USER_NAME}:${USER_NAME} --from=builder /build/src/odyssey/ ./src/odyssey/


### PR DESCRIPTION
Clears the 3 fixable Python findings in the published image (setuptools ×2, msgpack) by pinning the system-python versions in both Dockerfiles.

## What trivy flags (fresh scan 2026-08-18 01:19 of `odyssey:main`)

| CVE | Package | Installed | Fixed | Fix |
|---|---|---|---|---|
| CVE-2025-47273 | setuptools | 70.3.0 | 78.1.1 | pin 83.0.0 (also covers CVE-2026-59890) |
| CVE-2026-59890 | setuptools | 70.3.0 | 83.0.0 | pin 83.0.0 |
| GHSA-6v7p-g79w-8964 | msgpack | 1.1.2 | 1.2.1 | pin 1.2.1 |

These live in the **system python3** shipped by the ubuntu:24.04 base image (the app venv was already pinned via uv.lock — msgpack 1.2.1, setuptools build-backend ≥84). PEP 668 on noble requires `--break-system-packages`.

## Changes

- `Dockerfile` + `Dockerfile.ci` — after `uv sync`, upgrade system-python setuptools→83.0.0 and msgpack→1.2.1 (guarded on python3 presence).

Note: the 14 remaining apt-level findings (libgcrypt20, util-linux, zlib1g, systemd, p11-kit, shadow — all LOW/MEDIUM) have **no fixed version available in Ubuntu 24.04 repos**; they are tracked separately and will clear once upstream publishes patches.
