### PR TITLE
fix(1.0.0): remove workarounds for closed upstream issues

### DIFF
--- a/docs/dev/mojo-1.0.0-regressions.md
+++ b/docs/dev/mojo-1.0.0-regressions.md
@@ -288,11 +288,11 @@ the non-deterministic nature of FM-A.
 
 | Issue | Failure mode | Status | URL |
 | --- | --- | --- | --- |
-| FM-1 / FM-A | Return-move UAF | OPEN (closed DUPLICATE of #6707, no fix) — code-level WAR added 2026-08-23: `batch_norm2d_inplace` (in-place running-stat update, single-tensor return) for BN hot paths that previously extracted `Tuple[AnyTensor, AnyTensor, AnyTensor]` | [#6939](https://github.com/modular/modular/issues/6939) |
+| FM-1 / FM-A | Return-move UAF | CLOSED DUPLICATE of #6707 (expected behavior, no fix) — double-`__deinit__` **still reproducible on 1.0.0 stable** (verified 2026-08-26); canonical single-tensor-return shape retained (`batch_norm2d_inplace`); permanent canary `test_return_move_canary.mojo` (2026-08-25) | [#6939](https://github.com/modular/modular/issues/6939) |
 | FM-2 | Scalar pow compile | OPEN | [#6940](https://github.com/modular/modular/issues/6940) |
 | FM-3 | VM limit abort | OPEN | [#6941](https://github.com/modular/modular/issues/6941) |
-| FM-B | KGEN JIT runtime crash | OPEN | [#6958](https://github.com/modular/modular/issues/6958) |
-| FM-C | Premature `__deinit__` UAF from escaping `Atomic` pointers (`SpinLock._as_atomic`, `AtomicStats._counter`) | OPEN — WAR applied (no-escape API on both) | [#6959](https://github.com/modular/modular/issues/6959) |
+| FM-B | KGEN JIT runtime crash | CLOSED COMPLETED (2026-08-22) — not reproducible in the current suite (all 363 test files pass); no code workaround existed | [#6958](https://github.com/modular/modular/issues/6958) |
+| FM-C / #6963 | Premature `__deinit__` UAF from escaping `Atomic`/raw pointers | **#6959 CLOSED COMPLETED — verified FIXED on 1.0.0 stable (2026-08-26): workaround REMOVED**, original escaping API restored (`SpinLock.lock_word`, `AtomicStats._counter`); all spinlock/memory-pool tests pass. **#6963 closed DUPLICATE of #6707 (expected behavior — use proper origin-tracking)**: origin-tied `data_ptr` IS that guidance; "workaround" labels removed 2026-08-26, pattern retained as canonical | [#6959](https://github.com/modular/modular/issues/6959) · [#6963](https://github.com/modular/modular/issues/6963) |
 | FM-G | Premature `__deinit__` of closure captures when a `@parameter` capturing closure is passed as a function-value parameter (breaks `parallelize` batch paths in pooling/conv/normalization) | **Filed [#6965](https://github.com/modular/modular/issues/6965)** — WAR applied: inline TaskGroup dispatch at all 3 call sites (closure never crosses a function-value boundary); `parallelize` retained for scalar/keep-alive captures only | 2026-08-22 |
 
 ---
@@ -317,9 +317,12 @@ All 362 non-DISABLED test files now compile and run on 1.0.0 stable:
 - Owned-local raw-pointer-escape audit: **0 remaining** in `src/` (20
   migrated across 10 files to origin-tied `data_ptr[]`).
 
-Remaining known failure classes are all filed upstream: FM-A/return-move
-(#6939), FM-B/KGEN JIT (#6958), FM-C/Atomic + raw-pointer escape
-(#6959/#6963), FM-G/closure captures (#6965).
+Failure classes filed upstream (2026-08-26 status): FM-A/return-move
+(#6939, closed DUPLICATE — double-` still reproducible), FM-B/KGEN JIT
+(#6958, closed COMPLETED — not reproducible in the current suite),
+FM-C/Atomic (#6959, closed COMPLETED — verified fixed, workaround removed
+2026-08-26), raw-pointer escape (#6963, closed DUPLICATE — canonical
+origin-tied pattern retained), FM-G/closure captures (#6965, open).
 
 ---
 

--- a/examples/lenet_emnist/inference.mojo
+++ b/examples/lenet_emnist/inference.mojo
@@ -159,7 +159,7 @@ def infer_single(
     # Find argmax and max value
     var num_classes = logits.shape()[1]
     var max_idx = 0
-    # origin-tied data_ptr (WAR for modular/modular#6963): logits is an owned
+    # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): logits is an owned
     # local; a raw `_data` escape would let the compiler hoist its __deinit__
     # here, freeing the buffer while the argmax/softmax loops read it.
     var max_val_data = logits.data_ptr[DType.float32]()

--- a/examples/resnet18_cifar10/inference.mojo
+++ b/examples/resnet18_cifar10/inference.mojo
@@ -124,7 +124,7 @@ def evaluate_model(
         total_correct += batch_correct
 
         # Update per-class counters
-        # origin-tied data_ptr (WAR for modular/modular#6963): logits is an
+        # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): logits is an
         # owned local; a raw `_data` escape would let the compiler hoist its
         # __deinit__ here, freeing the buffer while the argmax loop reads it.
         var logits_data = logits.data_ptr[DType.float32]()

--- a/examples/resnet18_cifar10/test_forward_cache_velocities.mojo
+++ b/examples/resnet18_cifar10/test_forward_cache_velocities.mojo
@@ -177,7 +177,7 @@ def test_forward_with_cache_matches_forward_logits() raises:
 
     # Compare logit values element-wise: forward_with_cache must produce
     # bit-equal float32 logits to forward (40 logits = 4 batch x 10 classes).
-    # origin-tied data_ptr (WAR for modular/modular#6963): cache_logits and
+    # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): cache_logits and
     # forward_logits are owned locals; raw `_data` escapes would let the
     # compiler hoist their __deinit__ here, freeing the buffers while the
     # comparison loop still reads them.

--- a/examples/resnet18_cifar10/test_model.mojo
+++ b/examples/resnet18_cifar10/test_model.mojo
@@ -71,7 +71,7 @@ def main() raises:
 
     # Check for NaN/Inf
     print("\nChecking for NaN/Inf in outputs...")
-    # origin-tied data_ptr (WAR for modular/modular#6963): logits_train is an
+    # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): logits_train is an
     # owned local; a raw `_data` escape would let the compiler hoist its
     # __deinit__ here, freeing the buffer while the NaN loop reads it.
     var logits_data = logits_train.data_ptr[DType.float32]()

--- a/src/odyssey/autograd/variable.mojo
+++ b/src/odyssey/autograd/variable.mojo
@@ -582,7 +582,7 @@ def variable_neg(
     # Create negated tensor
     var result_data = zeros_like(x.data)
     var size = x.data.numel()
-    # Origin-tied pointer (WAR for modular/modular#6963): `result_data` is an
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `result_data` is an
     # owned local; a raw `_data` escape can hoist its __deinit__ mid-loop.
     var rd_ptr = result_data.data_ptr[DType.uint8]()
     for i in range(size):

--- a/src/odyssey/base/memory_pool.mojo
+++ b/src/odyssey/base/memory_pool.mojo
@@ -111,7 +111,7 @@ struct SpinLock(Copyable, Movable):
         for i in range(8):
             self._state[unsafe_offset=i] = 0
 
-    def _lock_word(self) -> Pointer[Int64, MutUntrackedOrigin]:
+    def lock_word(self) -> Pointer[Int64, MutUntrackedOrigin]:
         """Return the lock word as a plain Int64 pointer for static Atomic ops.
         """
         return self._state.unsafe_bitcast[Int64]()
@@ -132,7 +132,7 @@ struct SpinLock(Copyable, Movable):
         counter to its pre-attempt value, and the counter is bounded by the
         number of concurrently spinning threads (all within Int64 range).
         """
-        var word = self._lock_word()
+        var word = self.lock_word()
         while True:
             # Wait until lock looks free before attempting (reduces bus traffic)
             while Atomic[DType.int64].load(word) != 0:
@@ -159,36 +159,12 @@ struct SpinLock(Copyable, Movable):
         unmatched fetch_add(1) exists), making fetch_add(-1) always bring the
         counter from exactly 1 to 0.
         """
-        _ = Atomic[DType.int64].fetch_add(self._lock_word(), Int64(-1))
+        _ = Atomic[DType.int64].fetch_add(self.lock_word(), Int64(-1))
 
     def peek_counter(mut self) -> Int64:
-        """Atomically read the lock counter (0 = unlocked, 1 = locked).
-
-        WAR for modular/modular#6959 (see also #6707): exposing the raw
-        atomic pointer via `_as_atomic()` lets the raw pointer escape the
-        struct, and the 1.0.0 compiler then hoists `__deinit__` (the
-        `unsafe_free` of `_state`) to right after the last syntactic use of
-        the SpinLock — callers operate on freed memory.  These methods keep
-        all atomic access inside the struct so no pointer ever escapes.
-        """
-        return self._state.unsafe_bitcast[Atomic[DType.int64]]()[].load()
-
-    def fetch_add_counter(mut self, rhs: Int) -> Int64:
-        """Atomically add rhs to the lock counter; returns the previous value.
-
-        Same WAR rationale as `peek_counter` (no pointer escapes).
-        """
-        return self._state.unsafe_bitcast[Atomic[DType.int64]]()[].fetch_add(
-            Int64(rhs)
-        )
-
-    def fetch_sub_counter(mut self, rhs: Int) -> Int64:
-        """Atomically subtract rhs from the lock counter; returns the previous
-        value.  Same WAR rationale as `peek_counter` (no pointer escapes).
-        """
-        return self._state.unsafe_bitcast[Atomic[DType.int64]]()[].fetch_sub(
-            Int64(rhs)
-        )
+        """Atomically read the lock counter (0 = unlocked, 1 = locked)."""
+        var word = self.lock_word()
+        return Atomic[DType.int64].load(word)
 
     def __deinit__(deinit self):
         """Free the backing store."""
@@ -216,86 +192,52 @@ struct AtomicStats(Copyable, Movable):
         for i in range(_ASTATS_SIZE):
             self._data[unsafe_offset=i] = 0
 
-    def peek_counter(mut self, offset: Int) -> Int64:
-        """Atomically read the counter at the given byte offset.
+    def _counter(
+        self, offset: Int
+    ) -> Pointer[Atomic[DType.int64], MutUntrackedOrigin]:
+        """Get pointer to atomic counter at given byte offset."""
+        return self._data.unsafe_offset(offset).unsafe_bitcast[
+            Atomic[DType.int64]
+        ]()
 
-        WAR for modular/modular#6959 (see also #6707): `update_peak_cached`
-        used to hold the raw atomic pointer returned by `_counter()` in a
-        local, letting the pointer escape the struct. The 1.0.0 compiler
-        then hoists `__deinit__` (the `unsafe_free` of `_data`) to right
-        after the last syntactic use of the AtomicStats, so callers operate
-        on freed memory. These methods keep all atomic access inside the
-        struct so no pointer ever escapes.
+    def _counter_int64(self, offset: Int) -> Pointer[Int64, MutUntrackedOrigin]:
+        """Return a plain Int64 pointer at the given byte offset (for atomic
+        store).
         """
-        return (
-            self._data.unsafe_offset(offset)
-            .unsafe_bitcast[Atomic[DType.int64]]()[]
-            .load()
-        )
-
-    def fetch_add_counter(mut self, offset: Int, n: Int) -> Int64:
-        """Atomically add n to the counter at the given byte offset.
-
-        Same WAR rationale as `peek_counter` (no pointer escapes).
-        """
-        return (
-            self._data.unsafe_offset(offset)
-            .unsafe_bitcast[Atomic[DType.int64]]()[]
-            .fetch_add(Int64(n))
-        )
-
-    def max_counter(mut self, offset: Int, n: Int64):
-        """Atomically set the counter at the given byte offset to max(old, n).
-
-        Same WAR rationale as `peek_counter` (no pointer escapes).
-        """
-        _ = (
-            self._data.unsafe_offset(offset)
-            .unsafe_bitcast[Atomic[DType.int64]]()[]
-            .max(n)
-        )
-
-    def store_counter(mut self, offset: Int, value: Int):
-        """Atomically store value into the counter at the given byte offset.
-
-        Same WAR rationale as `peek_counter` (no pointer escapes).
-        """
-        Atomic[DType.int64].store(
-            self._data.unsafe_offset(offset).unsafe_bitcast[Int64](),
-            Int64(value),
-        )
+        return self._data.unsafe_offset(offset).unsafe_bitcast[Int64]()
 
     def add_allocations(mut self, n: Int):
         """Atomically increment allocations counter."""
-        _ = self.fetch_add_counter(_ASTATS_ALLOCATIONS, n)
+        _ = self._counter(_ASTATS_ALLOCATIONS)[].fetch_add(Int64(n))
 
     def add_deallocations(mut self, n: Int):
         """Atomically increment deallocations counter."""
-        _ = self.fetch_add_counter(_ASTATS_DEALLOCATIONS, n)
+        _ = self._counter(_ASTATS_DEALLOCATIONS)[].fetch_add(Int64(n))
 
     def add_pool_hits(mut self, n: Int):
         """Atomically increment pool hits counter."""
-        _ = self.fetch_add_counter(_ASTATS_POOL_HITS, n)
+        _ = self._counter(_ASTATS_POOL_HITS)[].fetch_add(Int64(n))
 
     def add_pool_misses(mut self, n: Int):
         """Atomically increment pool misses counter."""
-        _ = self.fetch_add_counter(_ASTATS_POOL_MISSES, n)
+        _ = self._counter(_ASTATS_POOL_MISSES)[].fetch_add(Int64(n))
 
     def add_bytes_allocated(mut self, n: Int):
         """Atomically adjust bytes allocated counter."""
-        _ = self.fetch_add_counter(_ASTATS_BYTES_ALLOCATED, n)
+        _ = self._counter(_ASTATS_BYTES_ALLOCATED)[].fetch_add(Int64(n))
 
     def add_bytes_cached(mut self, n: Int):
         """Atomically adjust bytes cached counter."""
-        _ = self.fetch_add_counter(_ASTATS_BYTES_CACHED, n)
+        _ = self._counter(_ASTATS_BYTES_CACHED)[].fetch_add(Int64(n))
 
     def update_peak_cached(mut self):
         """Update peak cached bytes if current cached exceeds it."""
-        var cached = self.peek_counter(_ASTATS_BYTES_CACHED)
+        var cached = self._counter(_ASTATS_BYTES_CACHED)[].load()
+        var peak_ptr = self._counter(_ASTATS_PEAK_CACHED)
         # Simple load-compare-store; minor races here are acceptable
         # since peak is a high-water-mark metric, not a correctness counter.
-        if cached > self.peek_counter(_ASTATS_PEAK_CACHED):
-            self.max_counter(_ASTATS_PEAK_CACHED, cached)
+        if cached > peak_ptr[].load():
+            peak_ptr[].max(Int64(cached))
 
     def snapshot(mut self) -> PoolStats:
         """Take a consistent snapshot of all counters.
@@ -304,13 +246,13 @@ struct AtomicStats(Copyable, Movable):
             A PoolStats struct with current counter values.
         """
         var s = PoolStats()
-        s.allocations = Int(self.peek_counter(_ASTATS_ALLOCATIONS))
-        s.deallocations = Int(self.peek_counter(_ASTATS_DEALLOCATIONS))
-        s.pool_hits = Int(self.peek_counter(_ASTATS_POOL_HITS))
-        s.pool_misses = Int(self.peek_counter(_ASTATS_POOL_MISSES))
-        s.bytes_allocated = Int(self.peek_counter(_ASTATS_BYTES_ALLOCATED))
-        s.bytes_cached = Int(self.peek_counter(_ASTATS_BYTES_CACHED))
-        s.peak_cached_bytes = Int(self.peek_counter(_ASTATS_PEAK_CACHED))
+        s.allocations = Int(self._counter(_ASTATS_ALLOCATIONS)[].load())
+        s.deallocations = Int(self._counter(_ASTATS_DEALLOCATIONS)[].load())
+        s.pool_hits = Int(self._counter(_ASTATS_POOL_HITS)[].load())
+        s.pool_misses = Int(self._counter(_ASTATS_POOL_MISSES)[].load())
+        s.bytes_allocated = Int(self._counter(_ASTATS_BYTES_ALLOCATED)[].load())
+        s.bytes_cached = Int(self._counter(_ASTATS_BYTES_CACHED)[].load())
+        s.peak_cached_bytes = Int(self._counter(_ASTATS_PEAK_CACHED)[].load())
         return s
 
     def reset(mut self):
@@ -323,13 +265,15 @@ struct AtomicStats(Copyable, Movable):
         Caller must ensure no concurrent allocate()/deallocate() calls are in
         flight (see module-level thread-safety note).
         """
-        self.store_counter(_ASTATS_ALLOCATIONS, 0)
-        self.store_counter(_ASTATS_DEALLOCATIONS, 0)
-        self.store_counter(_ASTATS_POOL_HITS, 0)
-        self.store_counter(_ASTATS_POOL_MISSES, 0)
-        self.store_counter(_ASTATS_BYTES_ALLOCATED, 0)
-        self.store_counter(_ASTATS_BYTES_CACHED, 0)
-        self.store_counter(_ASTATS_PEAK_CACHED, 0)
+        Atomic[DType.int64].store(self._counter_int64(_ASTATS_ALLOCATIONS), 0)
+        Atomic[DType.int64].store(self._counter_int64(_ASTATS_DEALLOCATIONS), 0)
+        Atomic[DType.int64].store(self._counter_int64(_ASTATS_POOL_HITS), 0)
+        Atomic[DType.int64].store(self._counter_int64(_ASTATS_POOL_MISSES), 0)
+        Atomic[DType.int64].store(
+            self._counter_int64(_ASTATS_BYTES_ALLOCATED), 0
+        )
+        Atomic[DType.int64].store(self._counter_int64(_ASTATS_BYTES_CACHED), 0)
+        Atomic[DType.int64].store(self._counter_int64(_ASTATS_PEAK_CACHED), 0)
 
     def __deinit__(deinit self):
         """Free the backing store."""
@@ -794,10 +738,10 @@ struct TensorMemoryPool(Copyable, Movable):
 
         # Reset byte counters only (preserve allocation/deallocation counts)
         var current_cached = Int(
-            self._atomic_stats.peek_counter(_ASTATS_BYTES_CACHED)
+            self._atomic_stats._counter(_ASTATS_BYTES_CACHED)[].load()
         )
         var current_alloc = Int(
-            self._atomic_stats.peek_counter(_ASTATS_BYTES_ALLOCATED)
+            self._atomic_stats._counter(_ASTATS_BYTES_ALLOCATED)[].load()
         )
         self._atomic_stats.add_bytes_cached(-current_cached)
         self._atomic_stats.add_bytes_allocated(-current_alloc)

--- a/src/odyssey/core/matmul.mojo
+++ b/src/odyssey/core/matmul.mojo
@@ -539,7 +539,7 @@ def _transpose_matrix_float32(b: AnyTensor, K: Int, N: Int) raises -> AnyTensor:
     var b_t = AnyTensor(b_t_shape, DType.float32)
 
     var b_ptr = b._data.unsafe_bitcast[Float32]()
-    # Origin-tied pointer (WAR for modular/modular#6963): `b_t` is an owned
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `b_t` is an owned
     # local; a raw `_data` escape can hoist its __deinit__ mid-transpose.
     var bt_ptr = b_t.data_ptr[DType.float32]()
 
@@ -565,7 +565,7 @@ def _transpose_matrix_float64(b: AnyTensor, K: Int, N: Int) raises -> AnyTensor:
     var b_t = AnyTensor(b_t_shape, DType.float64)
 
     var b_ptr = b._data.unsafe_bitcast[Float64]()
-    # Origin-tied pointer (WAR for modular/modular#6963): `b_t` is an owned
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `b_t` is an owned
     # local; a raw `_data` escape can hoist its __deinit__ mid-transpose.
     var bt_ptr = b_t.data_ptr[DType.float64]()
 
@@ -595,7 +595,7 @@ def _matmul_float32(
     var b_t = _transpose_matrix_float32(b, K, N)
 
     var a_ptr = a._data.unsafe_bitcast[Float32]()
-    # origin-tied data_ptr (WAR for modular/modular#6963): b_t is an owned
+    # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): b_t is an owned
     # local; a raw `_data` escape would let the compiler hoist b_t's
     # __deinit__ to this line, freeing the buffer while bt_ptr still reads it.
     var bt_ptr = b_t.data_ptr[DType.float32]()
@@ -723,7 +723,7 @@ def _matmul_float64(
     var b_t = _transpose_matrix_float64(b, K, N)
 
     var a_ptr = a._data.unsafe_bitcast[Float64]()
-    # origin-tied data_ptr (WAR for modular/modular#6963): see float32 twin.
+    # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): see float32 twin.
     var bt_ptr = b_t.data_ptr[DType.float64]()
     var c_ptr = c._data.unsafe_bitcast[Float64]()
 
@@ -1002,7 +1002,7 @@ def verify_matmul_correctness(M: Int, K: Int, N: Int) raises -> Bool:
     var b = AnyTensor(b_shape, DType.float32)
 
     # Initialize with simple values for reproducibility
-    # Origin-tied pointers (WAR for modular/modular#6963): `a`/`b` are owned
+    # Origin-tied pointers per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `a`/`b` are owned
     # locals; raw `_data` escapes can hoist their __deinit__ mid-fill.
     var a_ptr = a.data_ptr[DType.float32]()
     var b_ptr = b.data_ptr[DType.float32]()

--- a/src/odyssey/core/matrix.mojo
+++ b/src/odyssey/core/matrix.mojo
@@ -1337,7 +1337,7 @@ def tensordot(a: AnyTensor, b: AnyTensor, axes: Int) raises -> AnyTensor:
         # Copy data from original tensors
         var a_src = a._data.unsafe_bitcast[Scalar[DType.float32]]()
         var b_src = b._data.unsafe_bitcast[Scalar[DType.float32]]()
-        # Origin-tied pointers (WAR for modular/modular#6963): the reshaped
+        # Origin-tied pointers per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): the reshaped
         # locals are owned; raw `_data` escapes can hoist their __deinit__.
         var a_dst = a_reshaped.data_ptr[DType.float32]()
         var b_dst = b_reshaped.data_ptr[DType.float32]()

--- a/src/odyssey/core/normalization.mojo
+++ b/src/odyssey/core/normalization.mojo
@@ -278,6 +278,9 @@ def batch_norm2d_inplace(
     runs the moved-from source's `__deinit__`, over-decrementing AnyTensor's
     shared refcount -> premature free -> reads of the returned stats fields
     hit freed memory non-deterministically ("BN stats not persisted" flakes).
+    Upstream closed #6939 as DUPLICATE of #6707 (expected behavior) with NO
+    fix; the double-`__deinit__` remains reproducible on 1.0.0 stable
+    (verified 2026-08-26 via docs/dev/reproducers/repro_uaf_return_move.mojo).
     This variant returns a single tensor (the same reliable shape as
     conv/linear/cross_entropy on stable), so running stat persistence is
     guaranteed by in-place mutation instead of by tuple extraction.

--- a/src/odyssey/core/normalization_simd.mojo
+++ b/src/odyssey/core/normalization_simd.mojo
@@ -149,7 +149,7 @@ def _batch_norm2d_fused_inference_float32(
     var beta_ptr = beta._data.unsafe_bitcast[Float32]()
     var running_mean_ptr = running_mean._data.unsafe_bitcast[Float32]()
     var running_var_ptr = running_var._data.unsafe_bitcast[Float32]()
-    # Origin-tied pointer (WAR for modular/modular#6963): `result` is an
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `result` is an
     # owned local; a raw `_data` escape can hoist its __deinit__ and free
     # the buffer while the loop still writes it.
     var out_ptr = result.data_ptr[DType.float32]()
@@ -211,7 +211,7 @@ def _batch_norm2d_fused_inference_float64(
     var beta_ptr = beta._data.unsafe_bitcast[Float64]()
     var running_mean_ptr = running_mean._data.unsafe_bitcast[Float64]()
     var running_var_ptr = running_var._data.unsafe_bitcast[Float64]()
-    # Origin-tied pointer (WAR for modular/modular#6963): `result` is an
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `result` is an
     # owned local; a raw `_data` escape can hoist its __deinit__ and free
     # the buffer while the loop still writes it.
     var out_ptr = result.data_ptr[DType.float64]()
@@ -375,7 +375,7 @@ def _batch_norm2d_fused_training_float32(
     var running_var_ptr = running_var._data.unsafe_bitcast[Float32]()
 
     var output = AnyTensor(x.shape(), x._dtype)
-    # Origin-tied pointers (WAR for modular/modular#6963): `output`,
+    # Origin-tied pointers per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `output`,
     # `new_running_mean/var` are owned locals; raw `_data` escapes can hoist
     # their __deinit__ and free the buffers while the kernels still write.
     var out_ptr = output.data_ptr[DType.float32]()
@@ -503,7 +503,7 @@ def _batch_norm2d_fused_training_float64(
     var running_var_ptr = running_var._data.unsafe_bitcast[Float64]()
 
     var output = AnyTensor(x.shape(), x._dtype)
-    # Origin-tied pointers (WAR for modular/modular#6963): owned locals.
+    # Origin-tied pointers per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): owned locals.
     var out_ptr = output.data_ptr[DType.float64]()
 
     var new_running_mean = zeros_like(running_mean)

--- a/src/odyssey/core/normalize_ops.mojo
+++ b/src/odyssey/core/normalize_ops.mojo
@@ -84,7 +84,7 @@ def normalize_rgb(
     var normalized = zeros(shape, DType.float32)
 
     var src_data = images._data
-    # Origin-tied pointer (WAR for modular/modular#6963): `normalized` is an
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `normalized` is an
     # owned local; a raw `_data` escape can hoist its __deinit__ mid-loop.
     var dst_data = normalized.data_ptr[DType.float32]()
 

--- a/src/odyssey/data/formats/idx_loader.mojo
+++ b/src/odyssey/data/formats/idx_loader.mojo
@@ -235,7 +235,7 @@ def normalize_images(mut images: AnyTensor) raises -> AnyTensor:
 
     var num_elements = images.numel()
     var src_data = images._data
-    # Origin-tied pointer (WAR for modular/modular#6963): `normalized` is an
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `normalized` is an
     # owned local; a raw `_data` escape can hoist its __deinit__ mid-loop.
     var dst_data = normalized.data_ptr[DType.float32]()
 
@@ -278,7 +278,7 @@ def one_hot_encode(labels: AnyTensor, num_classes: Int) raises -> AnyTensor:
 
     # Fill one-hot encoding
     var labels_data = labels._data
-    # Origin-tied pointer (WAR for modular/modular#6963): `one_hot` is an
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `one_hot` is an
     # owned local; a raw `_data` escape can hoist its __deinit__ mid-loop.
     var one_hot_data = one_hot.data_ptr[DType.float32]()
 
@@ -330,7 +330,7 @@ def normalize_images_rgb(mut images: AnyTensor) raises -> AnyTensor:
     var width = shape[3]
 
     var src_data = images._data
-    # Origin-tied pointer (WAR for modular/modular#6963): `normalized` is an
+    # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `normalized` is an
     # owned local; a raw `_data` escape can hoist its __deinit__ mid-loop.
     var dst_data = normalized.data_ptr[DType.float32]()
 

--- a/src/odyssey/tensor/any_tensor.mojo
+++ b/src/odyssey/tensor/any_tensor.mojo
@@ -498,8 +498,11 @@ struct AnyTensor(
         decremented once for the destination and once for the moved-from
         source -> premature free -> use-after-free on the returned value.
         See docs/dev/reproducers/repro_uaf_return_move.mojo and
-        modular/modular#6939 for the minimal reproducer. Fixed upstream;
-        do NOT reintroduce the refcount-sentinel workaround here.
+        modular/modular#6939 for the minimal reproducer. Upstream closed
+        #6939 as DUPLICATE of #6707 (expected-behavior) with NO fix; the
+        triggered double-`__deinit__` is still reproducible on 1.0.0
+        stable (verified 2026-08-26). Do NOT reintroduce the
+        refcount-sentinel workaround here.
         """
         self._data = move._data
         self._base_data = move._base_data
@@ -1600,7 +1603,7 @@ struct AnyTensor(
     ](mut self,) -> Pointer[Scalar[dtype], origin_of(self)]:
         """Get typed pointer to underlying data for bulk operations.
 
-        WAR for modular/modular#6963 (premature `__deinit__` UAF, same class
+        per upstream lifetime guidance, modular/modular#6963 (closed DUPLICATE of #6707): premature `__deinit__` UAF, same class
         as #6959/#6707): the returned pointer is origin-tied to `self` so
         the compiler keeps this tensor alive for the whole lifetime of the
         pointer instead of hoisting `__deinit__` to right after this call.
@@ -1622,7 +1625,7 @@ struct AnyTensor(
     def refcount(mut self) -> Int:
         """Get the current shared reference count, tied to this tensor's lifetime.
 
-        WAR for modular/modular#6963 (premature `__deinit__` UAF, same class
+        per upstream lifetime guidance, modular/modular#6963 (closed DUPLICATE of #6707): premature `__deinit__` UAF, same class
         as #6959/#6707): reading `_refcount` directly on an owned local can
         hoist this tensor's `__deinit__` to right after the field access,
         freeing the refcount pointer before it is dereferenced. Taking `mut

--- a/src/odyssey/tensor/tensor.mojo
+++ b/src/odyssey/tensor/tensor.mojo
@@ -288,7 +288,7 @@ struct Tensor[dtype: DType = DType.float32](
     def data_ptr(mut self) -> Pointer[Scalar[Self.dtype], origin_of(self)]:
         """Get typed pointer to element data, tied to this tensor's lifetime.
 
-        WAR for modular/modular#6963 (premature `__deinit__` UAF, same class
+        per upstream lifetime guidance, modular/modular#6963 (closed DUPLICATE of #6707): premature `__deinit__` UAF, same class
         as #6959/#6707): the returned pointer is origin-tied to `self` so
         the compiler keeps this tensor alive for the whole lifetime of the
         pointer instead of hoisting `__deinit__` to right after this call.

--- a/src/odyssey/tensor/tensor_ops.mojo
+++ b/src/odyssey/tensor/tensor_ops.mojo
@@ -291,7 +291,7 @@ def _anytensor_matmul(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
         def _mm[dtype: DType]():
             var a_ptr = a._data.unsafe_bitcast[Scalar[dtype]]()
             var b_ptr = b._data.unsafe_bitcast[Scalar[dtype]]()
-            # Origin-tied pointer (WAR for modular/modular#6963): `result` is
+            # Origin-tied pointer per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): `result` is
             # an owned local; a raw `_data` escape can hoist its __deinit__.
             var r_ptr = result.data_ptr[dtype]()
             for i in range(m):

--- a/src/odyssey/tensor/typed/arithmetic.mojo
+++ b/src/odyssey/tensor/typed/arithmetic.mojo
@@ -91,7 +91,8 @@ def _broadcast_binary_typed[
 
     # Get typed pointers -- Tensor[dtype]._data is already typed, but
     # a_cont/b_cont are AnyTensor (from contiguity check), so use the
-    # origin-tied data_ptr (WAR for modular/modular#6963: direct `_data`
+    # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963,
+    # closed DUPLICATE of #6707): direct `_data`
     # access from an owned local hoists the owner's `__deinit__` before
     # the pointer is used, freeing the buffer mid-loop). Result uses the
     # native typed pointer directly.
@@ -236,7 +237,7 @@ def _multiply_scalar_typed[
     var result = Tensor[dt](t_cont.shape())
     var numel = result.numel()
 
-    # origin-tied data_ptr (WAR for modular/modular#6963): t_cont is an owned
+    # origin-tied data_ptr per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): t_cont is an owned
     # local; a raw `_data` escape would let the compiler hoist t_cont's
     # __deinit__ to this line, freeing the buffer while input_ptr reads it.
     var input_ptr = t_cont.data_ptr[dt]()

--- a/src/odyssey/tensor/typed/shape.mojo
+++ b/src/odyssey/tensor/typed/shape.mojo
@@ -50,7 +50,7 @@ def _as_contiguous_typed[
     var shape = tensor.shape()
     var numel = tensor.numel()
     var result = Tensor[dtype](shape)
-    # Origin-tied pointers (WAR for modular/modular#6963: direct `_data`
+    # Origin-tied pointers per upstream lifetime guidance (modular/modular#6963, closed DUPLICATE of #6707): direct `_data`
     # capture from an owned local hoists the owner's `__deinit__` before
     # the pointer is used, freeing the buffer mid-copy). `tensor` is a
     # borrowed param (owner is the caller — safe); `result` is an owned

--- a/tests/odyssey/base/test_spinlock_contention.mojo
+++ b/tests/odyssey/base/test_spinlock_contention.mojo
@@ -38,15 +38,26 @@ fix preserves.
 from std.testing import assert_true, assert_equal
 from odyssey.base.memory_pool import SpinLock
 from std.atomic import Atomic
-from std.memory import Pointer, alloc
+from std.memory import Pointer
+
+
+def _lock_atomic(
+    lk: SpinLock,
+) -> Pointer[Atomic[DType.int64], MutUntrackedOrigin]:
+    """Raw atomic view of the lock word, for contender simulation."""
+    return lk.lock_word().unsafe_bitcast[Atomic[DType.int64]]()
+
+
+def _peek(lk: SpinLock) -> Int64:
+    """Read the raw lock counter through the public lock_word() accessor."""
+    return _lock_atomic(lk)[].load()
 
 
 def test_lock_sets_counter_to_one() raises:
     """After lock(), the backing counter must be exactly 1 (locked state)."""
     var lk = SpinLock()
     lk.lock()
-    # Peek at the raw counter value through the internal atomic view.
-    var val = Int(lk.peek_counter())
+    var val = Int(_peek(lk))
     assert_equal(val, 1, "counter must be 1 after lock()")
     lk.unlock()
     print("PASS: test_lock_sets_counter_to_one")
@@ -57,7 +68,7 @@ def test_unlock_resets_counter_to_zero() raises:
     var lk = SpinLock()
     lk.lock()
     lk.unlock()
-    var val = Int(lk.peek_counter())
+    var val = Int(_peek(lk))
     assert_equal(val, 0, "counter must be 0 after unlock()")
     print("PASS: test_unlock_resets_counter_to_zero")
 
@@ -69,7 +80,7 @@ def test_double_lock_unlock_cycle() raises:
     lk.unlock()
     lk.lock()
     lk.unlock()
-    var val = Int(lk.peek_counter())
+    var val = Int(_peek(lk))
     assert_equal(val, 0, "counter must be 0 after two lock/unlock cycles")
     print("PASS: test_double_lock_unlock_cycle")
 
@@ -93,15 +104,15 @@ def test_failed_fetch_add_does_not_corrupt_counter() raises:
     lk.lock()
     # Simulate 3 contenders each doing add-then-sub (backing off)
     for _ in range(3):
-        _ = lk.fetch_add_counter(1)  # contender increments
-        _ = lk.fetch_sub_counter(1)  # contender backs off
+        _ = _lock_atomic(lk)[].fetch_add(Int64(1))  # contender increments
+        _ = _lock_atomic(lk)[].fetch_sub(Int64(1))  # contender backs off
     # Counter must still be 1 (lock still held by original owner)
-    var val = Int(lk.peek_counter())
+    var val = Int(_peek(lk))
     assert_equal(
         val, 1, "counter must stay 1 while lock is held despite contenders"
     )
     lk.unlock()
-    var final = Int(lk.peek_counter())
+    var final = Int(_peek(lk))
     assert_equal(final, 0, "counter must be 0 after unlock")
     print("PASS: test_failed_fetch_add_does_not_corrupt_counter")
 
@@ -122,19 +133,21 @@ def test_store_zero_unlock_would_corrupt_counter() raises:
     var lk = SpinLock()
     lk.lock()
     # Simulate contender: fetch_add(1) increments counter to 2
-    _ = lk.fetch_add_counter(1)
+    _ = _lock_atomic(lk)[].fetch_add(Int64(1))
     # Lock holder unlocks via fetch_add(-1): counter goes 2→1 (not 0!)
     # (If unlock() used store(0), counter would be 0 here — contender sees
     # free and enters while it shouldn't yet, because it hasn't done its undo.)
-    _ = lk.fetch_add_counter(-1)  # mimic unlock via fetch_add(-1)
-    var after_unlock = Int(lk.peek_counter())
+    _ = _lock_atomic(lk)[].fetch_add(
+        Int64(-1)
+    )  # mimic unlock via fetch_add(-1)
+    var after_unlock = Int(_peek(lk))
     assert_true(
         after_unlock >= 0,
         "counter must not go negative after unlock-via-fetch_add(-1)",
     )
     # Contender backs off: fetch_add(-1) → counter returns to 0
-    _ = lk.fetch_add_counter(-1)
-    var final = Int(lk.peek_counter())
+    _ = _lock_atomic(lk)[].fetch_add(Int64(-1))
+    var final = Int(_peek(lk))
     assert_equal(final, 0, "counter must reach 0 after contender backs off")
     print("PASS: test_store_zero_unlock_would_corrupt_counter")
 
@@ -151,14 +164,14 @@ def test_counter_never_negative_under_repeated_contention() raises:
     for _ in range(20):
         lk.lock()
         # Two contenders both attempt to acquire and then back off
-        _ = lk.fetch_add_counter(1)
-        _ = lk.fetch_add_counter(1)
-        _ = lk.fetch_add_counter(-1)
-        _ = lk.fetch_add_counter(-1)
-        var mid = Int(lk.peek_counter())
+        _ = _lock_atomic(lk)[].fetch_add(Int64(1))
+        _ = _lock_atomic(lk)[].fetch_add(Int64(1))
+        _ = _lock_atomic(lk)[].fetch_add(Int64(-1))
+        _ = _lock_atomic(lk)[].fetch_add(Int64(-1))
+        var mid = Int(_peek(lk))
         assert_true(mid >= 0, "counter must not go negative while lock is held")
         lk.unlock()
-        var post = Int(lk.peek_counter())
+        var post = Int(_peek(lk))
         assert_equal(post, 0, "counter must be 0 after unlock")
     print("PASS: test_counter_never_negative_under_repeated_contention")
 
@@ -174,7 +187,7 @@ def test_many_sequential_cycles_no_drift() raises:
     for _ in range(50):
         lk.lock()
         lk.unlock()
-    var val = Int(lk.peek_counter())
+    var val = Int(_peek(lk))
     assert_equal(
         val, 0, "counter must be exactly 0 after 50 lock/unlock cycles"
     )


### PR DESCRIPTION
Closes part of the Mojo 1.0.0 WAR cleanup. Triage of every workaround against its upstream issue's current state (2026-08-26):

## Removed (verified fixed)
- **modular/modular#6959** (Atomic fetch_add regression) — CLOSED COMPLETED. Empirically verified FIXED on 1.0.0 stable: restored the pre-WAR escaping API (`SpinLock.lock_word`, `AtomicStats._counter`, held-pointer `update_peak_cached`) and deleted the no-escape workaround methods. All spinlock + memory-pool tests pass (7/7 contention, double-free, threadsafe pool).

## Reclassified (closed as expected behavior; pattern IS upstream's guidance)
- **#6963** — CLOSED DUPLICATE of #6707 with explicit guidance to use proper origin-tracking. The origin-tied `data_ptr` pattern *is* that guidance → dropped the "WAR" label across 15 files, retained the canonical pattern.
- **#6939** — CLOSED DUPLICATE, no fix; double-`__deinit__` **still reproducible** on stable (verified via `repro_uaf_return_move.mojo` — two deinit prints). `batch_norm2d_inplace` single-tensor-return shape retained as canonical; FM-A canary remains the watchdog; corrected a stale "Fixed upstream" note in `any_tensor.mojo`.

## Unchanged (still open upstream)
- **#6940** (Scalar pow compile) and **#6941** (VM-limit abort) — workarounds + notes kept.

## Docs
- `docs/dev/mojo-1.0.0-regressions.md` issue tracker updated with verified statuses.

## Verification
- SpinLock contention (7/7), double-free, memory pool + threadsafe pool tests pass
- Escape audit gate: 0 sites
- Pre-commit: all hooks pass (Mojo Format, audit gate, Markdown, coverage)