### PR TITLE
[Docs] Correct WAR status for closed upstream issues #6187/#6475/#6959

### DIFF
--- a/docs/dev/mojo-1.0.0-regressions.md
+++ b/docs/dev/mojo-1.0.0-regressions.md
@@ -186,13 +186,15 @@ issue for it.
 
 ## Upstream issue status
 
-- **modular/modular#6187** (heap corruption, `0.26.1`) — closed COMPLETED; different
-  signature (crash at alloc, not move semantics).
+- **modular/modular#6187** (heap corruption, `0.26.1`) — closed COMPLETED (2026-03-26);
+  different signature (crash at alloc, not move semantics). The `data_ptr` keep-alive
+  pattern once attributed to it remains canonical, now cited against the still-open
+  premature-deinit class #6707/#6939.
 - **modular/modular#6707** (stale read through `UnsafePointer[MutUntrackedOrigin]`,
   closed NOT_PLANNED "expected behavior") — different mechanism: origin-tracking
   limitation, not a move-semantics violation.
-- **modular/modular#6475** (bitcast read in struct method vs external, OPEN) — different
-  mechanism (no moves involved).
+- **modular/modular#6475** (bitcast read in struct method vs external) — closed COMPLETED
+  (2026-08-23); different mechanism (no moves involved).
 
 All failure modes have been filed upstream (2026-08-20/21):
 
@@ -248,7 +250,7 @@ stdout/stderr capture. Classification:
 | --- | --- | --- | --- |
 | **FM-A: Memory corruption** | 49 tests | [#6939](https://github.com/modular/modular/issues/6939) | Return-move `__deinit__` UAF — garbage values (`~1.75`, `~4e-41`, `0.0`) or NaN in forward/backward passes |
 | **FM-B: KGEN JIT crash** | 4 tests | [#6958](https://github.com/modular/modular/issues/6958) | Runtime segfault in `libKGENCompilerRTShared.so` after successful compilation |
-| **FM-C: Atomic regression** | 1 test | [#6959](https://github.com/modular/modular/issues/6959) | Premature `__deinit__` UAF (same class as [#6707](https://github.com/modular/modular/issues/6707)) — the compiler hoists `unsafe_free` to right after the last syntactic use of a struct whose raw `Atomic` pointer escaped (e.g. `SpinLock._as_atomic`, `AtomicStats._counter` held in a local), so subsequent `Atomic` ops hit freed memory; the counter value is whatever the freed chunk holds. **WAR applied** (no pointer escapes from `SpinLock` or `AtomicStats`); repro still fails on stable |
+| **FM-C: Atomic regression** | 1 test | [#6959](https://github.com/modular/modular/issues/6959) | Premature `__deinit__` UAF (same class as [#6707](https://github.com/modular/modular/issues/6707)) — the compiler hoists `unsafe_free` to right after the last syntactic use of a struct whose raw `Atomic` pointer escaped (e.g. `SpinLock._as_atomic`, `AtomicStats._counter` held in a local), so subsequent `Atomic` ops hit freed memory; the counter value is whatever the freed chunk holds. **WAR removed 2026-08-26** (upstream closed as expected-behavior, NOT a compiler fix — the caller-side escape repro still fails on stable); production is safe because its escapes are borrow-internal (see tracker) |
 | **FM-D: Timeout/OOM** | 4 tests | N/A (resource limit) | Heavy model tests (AlexNet/VGG16 224×224, MobileNet train) timeout on 4-core container |
 | **FM-E: Non-deterministic** | 6 tests | (same as FM-A) | Pass on re-run; failed in full suite due to FM-A non-determinism |
 | **FM-F: Pre-existing** | 2 tests | **FIXED + re-enabled 2026-08-22** | `DISABLED_test_batchnorm` (SIMD type constraint) and `DISABLED_test_conv2d` (escape-UAF `_data` write in `test_conv2d_forward_batch_independence`) — both fixed and renamed back to `test_batchnorm.mojo` / `test_conv2d.mojo`; additionally `_batch_norm2d_fused_training_{float32,float64}` and both inference paths in `normalization_simd.mojo` migrated to origin-tied `data_ptr` (raw `_data` escapes on owned locals — the #6963 class) |
@@ -292,7 +294,7 @@ the non-deterministic nature of FM-A.
 | FM-2 | Scalar pow compile | OPEN | [#6940](https://github.com/modular/modular/issues/6940) |
 | FM-3 | VM limit abort | OPEN | [#6941](https://github.com/modular/modular/issues/6941) |
 | FM-B | KGEN JIT runtime crash | CLOSED COMPLETED (2026-08-22) — not reproducible in the current suite (all 363 test files pass); no code workaround existed | [#6958](https://github.com/modular/modular/issues/6958) |
-| FM-C / #6963 | Premature `__deinit__` UAF from escaping `Atomic`/raw pointers | **#6959 CLOSED COMPLETED — verified FIXED on 1.0.0 stable (2026-08-26): workaround REMOVED**, original escaping API restored (`SpinLock.lock_word`, `AtomicStats._counter`); all spinlock/memory-pool tests pass. **#6963 closed DUPLICATE of #6707 (expected behavior — use proper origin-tracking)**: origin-tied `data_ptr` IS that guidance; "workaround" labels removed 2026-08-26, pattern retained as canonical | [#6959](https://github.com/modular/modular/issues/6959) · [#6963](https://github.com/modular/modular/issues/6963) |
+| FM-C / #6963 | Premature `__deinit__` UAF from escaping `Atomic`/raw pointers | **#6959 CLOSED COMPLETED (2026-08-22, maintainer: "lifetime gotcha") — NOT a compiler fix**: the caller-side owned-local escape repro (`repro/repro_6959_inline.mojo`) **still FAILS 5/5 on 1.0.0 stable** (verified 2026-08-26). The prior "verified FIXED" claim was wrong — it was based on tests that only use single-expression escapes. WAR removal is nonetheless **safe**: production escapes are borrow-internal (pointer derived from borrowed `self` within a method, owner kept alive by the caller frame), verified by `docs/dev/reproducers/probe_update_peak_shape.mojo` passing 5/5 on the exact `update_peak_cached` shape. **#6963 closed DUPLICATE of #6707 (expected behavior — use proper origin-tracking)**: origin-tied `data_ptr` IS that guidance; "workaround" labels removed 2026-08-26, pattern retained as canonical | [#6959](https://github.com/modular/modular/issues/6959) · [#6963](https://github.com/modular/modular/issues/6963) |
 | FM-G | Premature `__deinit__` of closure captures when a `@parameter` capturing closure is passed as a function-value parameter (breaks `parallelize` batch paths in pooling/conv/normalization) | **Filed [#6965](https://github.com/modular/modular/issues/6965)** — WAR applied: inline TaskGroup dispatch at all 3 call sites (closure never crosses a function-value boundary); `parallelize` retained for scalar/keep-alive captures only | 2026-08-22 |
 
 ---
@@ -318,10 +320,12 @@ All 362 non-DISABLED test files now compile and run on 1.0.0 stable:
   migrated across 10 files to origin-tied `data_ptr[]`).
 
 Failure classes filed upstream (2026-08-26 status): FM-A/return-move
-(#6939, closed DUPLICATE — double-` still reproducible), FM-B/KGEN JIT
+(#6939, closed DUPLICATE — double-`__deinit__` still reproducible), FM-B/KGEN JIT
 (#6958, closed COMPLETED — not reproducible in the current suite),
-FM-C/Atomic (#6959, closed COMPLETED — verified fixed, workaround removed
-2026-08-26), raw-pointer escape (#6963, closed DUPLICATE — canonical
+FM-C/Atomic (#6959, closed COMPLETED as expected-behavior — the caller-side
+escape repro still fails on stable, but production escapes are borrow-internal
+so the WAR removal stands; probe evidence 2026-08-26), raw-pointer escape
+(#6963, closed DUPLICATE — canonical
 origin-tied pattern retained), FM-G/closure captures (#6965, open).
 
 ---

--- a/docs/dev/reproducers/probe_update_peak_shape.mojo
+++ b/docs/dev/reproducers/probe_update_peak_shape.mojo
@@ -1,0 +1,126 @@
+"""Probe: does the exact `AtomicStats.update_peak_cached` held-pointer shape
+still corrupt on Mojo 1.0.0 stable?
+
+The prior WAR removal for modular/modular#6959 (PR #5804) was validated only
+against tests that use single-expression escapes (`_counter(off)[].load()` —
+pointer consumed in the same statement).  The standalone repro
+(repro/repro_6959_inline.mojo) still FAILS on stable, and it uses the
+held-in-local shape (`var ptr = obj._as_atomic()` then `ptr[]` in later
+statements).
+
+This probe mirrors `update_peak_cached` exactly:
+
+    var cached = self._counter(_ASTATS_BYTES_CACHED)[].load()   # self last used here?
+    var peak_ptr = self._counter(_ASTATS_PEAK_CACHED)            # pointer held in local
+    if cached > peak_ptr[].load():
+        peak_ptr[].max(Int64(cached))
+
+`bytes_cached` is a RUNNING TOTAL (delta-based: add_bytes_cached can be
+negative), so the model here mirrors that.  The regression case is cached
+dropping BELOW peak — peak must stay.
+
+Run: mojo run docs/dev/reproducers/probe_update_peak_shape.mojo
+"""
+
+from std.atomic import Atomic
+from std.memory import Pointer
+from std.memory.alloc import unsafe_alloc
+from std.testing import assert_equal
+
+
+struct AtomicStats(Copyable, Movable):
+    """Mirror of Odyssey's AtomicStats (src/odyssey/base/memory_pool.mojo)."""
+
+    var _data: Pointer[UInt8, MutUntrackedOrigin]
+
+    def __init__(out self):
+        self._data = unsafe_alloc[UInt8](8 * 8)
+        for i in range(8 * 8):
+            self._data[unsafe_offset=i] = 0
+
+    def _counter(
+        self, offset: Int
+    ) -> Pointer[Atomic[DType.int64], MutUntrackedOrigin]:
+        return self._data.unsafe_offset(offset).unsafe_bitcast[
+            Atomic[DType.int64]
+        ]()
+
+    def add_bytes_cached(mut self, n: Int):
+        _ = self._counter(16)[].fetch_add(Int64(n))
+
+    def add_bytes_allocated(mut self, n: Int):
+        _ = self._counter(8)[].fetch_add(Int64(n))
+
+    def update_peak_cached(mut self):
+        """Byte-for-byte the production shape (post-#5804 revert)."""
+        var cached = self._counter(16)[].load()
+        var peak_ptr = self._counter(24)
+        if cached > peak_ptr[].load():
+            peak_ptr[].max(Int64(cached))
+
+    def peak(mut self) -> Int64:
+        return self._counter(24)[].load()
+
+    def __deinit__(deinit self):
+        self._data.unsafe_free()
+
+
+struct Pool(Copyable, Movable):
+    """Outer owner, mirroring MemoryPool holding AtomicStats as a field."""
+
+    var stats: AtomicStats
+
+    def __init__(out self):
+        self.stats = AtomicStats()
+
+    def update(mut self, cached_delta: Int):
+        """Delta update: bytes_cached running total += cached_delta."""
+        self.stats.add_bytes_cached(cached_delta)
+        self.stats.update_peak_cached()
+
+    def peak(mut self) -> Int64:
+        return self.stats.peak()
+
+
+def main() raises:
+    print("=== Probe: update_peak_cached held-pointer shape on stable ===")
+
+    # Running total semantics: cached accumulates; peak = max over time.
+    # cached: 0 -> +500 -> 500, peak = 500
+    var p = Pool()
+    p.update(500)
+    var peak1 = Int(p.peak())
+    print("  after +500: peak =", peak1, "(expected 500)")
+    assert_equal(peak1, 500, "peak must track cached (500)")
+
+    # cached: 500 -> +300 -> 800, peak = 800
+    p.update(300)
+    var peak2 = Int(p.peak())
+    print("  after +300: peak =", peak2, "(expected 800)")
+    assert_equal(peak2, 800, "peak must track new high (800)")
+
+    # cached: 800 -> -600 -> 200 (drops below peak) -> peak must stay 800
+    p.update(-600)
+    var peak3 = Int(p.peak())
+    print("  after -600: peak =", peak3, "(expected 800, unchanged)")
+    assert_equal(peak3, 800, "peak must not regress (800)")
+
+    # cached: 200 -> +700 -> 900 (new high) -> peak = 900
+    p.update(700)
+    var peak4 = Int(p.peak())
+    print("  after +700: peak =", peak4, "(expected 900)")
+    assert_equal(peak4, 900, "peak must track new high (900)")
+
+    print("All assertions passed!")
+
+    # Heavy churn to shake out latent UAF.  `update` applies deltas, so the
+    # running total after N=1000 iterations of i*7 is 7 * sum(0..999)
+    # = 7 * 999*1000/2 = 3,496,500 — and peak must track that.
+    var q = Pool()
+    for i in range(1000):
+        q.update(i * 7)
+    var churn_peak = Int(q.peak())
+    var expect = 7 * 999 * 1000 // 2
+    print("  churn peak:", churn_peak, "(expected", expect, ")")
+    assert_equal(churn_peak, expect, "peak must track max over churn")
+    print("All assertions passed (incl. churn)!")

--- a/docs/dev/upstream-issue-drafts/fm1-return-move-uaf.md
+++ b/docs/dev/upstream-issue-drafts/fm1-return-move-uaf.md
@@ -116,4 +116,4 @@ as wrong tensor values, `List._realloc` crashes, and flaky failures across the t
   heavy churn, not move semantics
 - #6707 (stale read through `UnsafePointer[MutUntrackedOrigin]`, closed NOT_PLANNED) —
   different mechanism: origin-tracking limitation, no move involved
-- #6475 (bitcast read in struct method, OPEN) — different mechanism, no moves involved
+- #6475 (bitcast read in struct method, closed COMPLETED) — different mechanism, no moves involved

--- a/src/odyssey/tensor/any_tensor.mojo
+++ b/src/odyssey/tensor/any_tensor.mojo
@@ -1558,8 +1558,10 @@ struct AnyTensor(
     # Use data_ptr[dtype]() when SIMD load/store or bulk pointer ops are needed.
     #
     # Why: Mojo's ASAP destruction can free tensors whose bitcast-derived
-    # pointers are still live (modular/modular#6187). These methods keep
-    # `self` alive for the duration of the access.
+    # pointers are still live (the premature-deinit class, modular/modular#6707
+    # / #6939). These methods keep `self` alive for the duration of the access.
+    # (modular/modular#6187, originally cited here, was fixed upstream; the
+    # origin-tie keep-alive remains canonical per #6707/#6939 guidance.)
     # ===----------------------------------------------------------------------===#
 
     @always_inline

--- a/src/odyssey/testing/gradient_checker.mojo
+++ b/src/odyssey/testing/gradient_checker.mojo
@@ -40,9 +40,11 @@ Fix for intermittent JIT crashes (issue #5104):
     All tight loops now use data_ptr[dtype]() to obtain typed pointers once
     per loop scope, replacing per-element _get_float64/_set_float64 calls.
     The per-element bitcast in _get/_set_float64 could trigger ASAP destruction
-    of the tensor while bitcast-derived pointers were still live
-    (modular/modular#6187). The data_ptr approach keeps the tensor alive for
-    the entire pointer scope.
+    of the tensor while bitcast-derived pointers were still live (the
+    premature-deinit class, modular/modular#6707 / #6939). The data_ptr
+    approach keeps the tensor alive for the entire pointer scope.
+    (Note: modular/modular#6187, originally cited here, was fixed upstream;
+    the origin-tie keep-alive remains canonical per #6707/#6939 guidance.)
 """
 
 from odyssey.tensor.any_tensor import AnyTensor
@@ -113,8 +115,8 @@ struct IndexGradientPair(Copyable, Movable):
 # These helpers use data_ptr[dtype]() to get a typed pointer ONCE, then
 # index that pointer throughout the loop. This keeps the source tensor
 # alive for the entire scope, preventing ASAP destruction from freeing
-# tensor memory while a bitcast-derived pointer is still in use
-# (modular/modular#6187).
+# tensor memory while a bitcast-derived pointer is still in use (the
+# premature-deinit class, modular/modular#6707 / #6939).
 # ============================================================================
 
 
@@ -243,7 +245,7 @@ def _check_gradients_perturb[
         # Use data_ptr[dtype]() once per tensor to keep output_plus/output_minus
         # alive for the entire loop scope. Per-element _get_float64 performs a
         # bitcast on each call and can trigger ASAP destruction of the temporary
-        # tensor before all elements are read (modular/modular#6187).
+        # tensor before all elements are read (premature-deinit class, #6707/#6939).
         var out_plus_ptr = output_plus.data_ptr[dtype]()
         var out_minus_ptr = output_minus.data_ptr[dtype]()
         var numerical_sum: Float64 = 0.0
@@ -298,7 +300,7 @@ def _check_gradients_perturb[
         # Use data_ptr[dtype]() once per tensor to keep output_plus/output_minus
         # alive for the entire loop scope. Per-element _get_float64 performs a
         # bitcast on each call and can trigger ASAP destruction of the temporary
-        # tensor before all elements are read (modular/modular#6187).
+        # tensor before all elements are read (premature-deinit class, #6707/#6939).
         var out_plus_ptr = output_plus.data_ptr[dtype]()
         var out_minus_ptr = output_minus.data_ptr[dtype]()
         var numerical_sum: Float64 = 0.0
@@ -974,7 +976,7 @@ def _compute_numerical_grad_perturb[
         # Central difference: (f(x+ε) - f(x-ε)) / 2ε
         # Use data_ptr[dtype]() to keep f_plus/f_minus alive for the loop
         # scope. Per-element _get_float64 bitcasts can trigger ASAP destruction
-        # of temporary tensors returned by forward_fn (modular/modular#6187).
+        # of temporary tensors returned by forward_fn (premature-deinit class, #6707/#6939).
         var f_plus_ptr = f_plus.data_ptr[dtype]()
         var f_minus_ptr = f_minus.data_ptr[dtype]()
         var grad_val: Float64
@@ -1201,7 +1203,7 @@ def _compute_sampled_grad_perturb[
         # f(x + ε)
         x_ptr[unsafe_offset=idx] = Scalar[dtype](original_val + epsilon)
         var f_plus = forward_fn(x)
-        # Use data_ptr[dtype]() to keep f_plus alive across the loop (modular/modular#6187)
+        # Use data_ptr[dtype]() to keep f_plus alive across the loop (#6707/#6939 class)
         var f_plus_ptr = f_plus.data_ptr[dtype]()
         var f_plus_sum: Float64 = 0.0
         for j in range(f_plus.numel()):
@@ -1210,7 +1212,7 @@ def _compute_sampled_grad_perturb[
         # f(x - ε)
         x_ptr[unsafe_offset=idx] = Scalar[dtype](original_val - epsilon)
         var f_minus = forward_fn(x)
-        # Use data_ptr[dtype]() to keep f_minus alive across the loop (modular/modular#6187)
+        # Use data_ptr[dtype]() to keep f_minus alive across the loop (#6707/#6939 class)
         var f_minus_ptr = f_minus.data_ptr[dtype]()
         var f_minus_sum: Float64 = 0.0
         for j in range(f_minus.numel()):
@@ -1652,7 +1654,7 @@ def _check_gradient_perturb[
         var plus_ptr = x_plus.data_ptr[dtype]()
         plus_ptr[unsafe_offset=i] = Scalar[dtype](old_val + eps)
         var out_plus = forward_fn(x_plus)
-        # Use data_ptr[dtype]() to keep out_plus alive across the loop (modular/modular#6187)
+        # Use data_ptr[dtype]() to keep out_plus alive across the loop (#6707/#6939 class)
         var out_plus_ptr = out_plus.data_ptr[dtype]()
         var grad_out_ptr = grad_output.data_ptr[dtype]()
         var loss_plus: Float64 = 0.0
@@ -1666,7 +1668,7 @@ def _check_gradient_perturb[
         var minus_ptr = x_minus.data_ptr[dtype]()
         minus_ptr[unsafe_offset=i] = Scalar[dtype](old_val - eps)
         var out_minus = forward_fn(x_minus)
-        # Use data_ptr[dtype]() to keep out_minus alive across the loop (modular/modular#6187)
+        # Use data_ptr[dtype]() to keep out_minus alive across the loop (#6707/#6939 class)
         var out_minus_ptr = out_minus.data_ptr[dtype]()
         var loss_minus: Float64 = 0.0
         for j in range(out_minus.numel()):
@@ -1708,7 +1710,7 @@ def _check_gradient_perturb[
         var plus_ptr = x_plus.data_ptr[dtype]()
         plus_ptr[unsafe_offset=i] = Scalar[dtype](old_val + eps)
         var out_plus = forward_fn(x_plus)
-        # Use data_ptr[dtype]() to keep out_plus alive across the loop (modular/modular#6187)
+        # Use data_ptr[dtype]() to keep out_plus alive across the loop (#6707/#6939 class)
         var out_plus_ptr = out_plus.data_ptr[dtype]()
         var grad_out_ptr = grad_output.data_ptr[dtype]()
         var loss_plus: Float64 = 0.0
@@ -1722,7 +1724,7 @@ def _check_gradient_perturb[
         var minus_ptr = x_minus.data_ptr[dtype]()
         minus_ptr[unsafe_offset=i] = Scalar[dtype](old_val - eps)
         var out_minus = forward_fn(x_minus)
-        # Use data_ptr[dtype]() to keep out_minus alive across the loop (modular/modular#6187)
+        # Use data_ptr[dtype]() to keep out_minus alive across the loop (#6707/#6939 class)
         var out_minus_ptr = out_minus.data_ptr[dtype]()
         var loss_minus: Float64 = 0.0
         for j in range(out_minus.numel()):


### PR DESCRIPTION
## Summary

Re-audit of every workaround reference in the codebase against its upstream modular issue's current state found three stale items left over from the prior WAR cleanup (#5804). Two are pure doc/comment corrections; one is a **significant correction to a wrong claim**.

## Changes Made

### 1. #6187 (CLOSED COMPLETED 2026-03-26) — comment reframe (12 sites)
The `data_ptr[dtype]()` keep-alive pattern in `gradient_checker.mojo` and `any_tensor.mojo` was cited as a workaround for #6187 (heap corruption at alloc, since fixed). The pattern actually guards the **still-open premature-deinit class** (#6707/#6939, closed as "expected behavior" — no fix). All 12 citations reframed to point at the real, still-relevant class; notes added that #6187 is fixed upstream.

### 2. #6475 (CLOSED COMPLETED 2026-08-23) — doc fix
`fm1-return-move-uaf.md` and the regressions tracker claimed this was OPEN. Corrected to CLOSED COMPLETED.

### 3. #6959 — corrected a WRONG "verified FIXED" claim (the important one)
The prior session removed the #6959 WAR claiming it was "verified FIXED on 1.0.0 stable". That was **wrong**:
- The standalone repro (`repro/repro_6959_inline.mojo`) **still FAILS 5/5 on stable** (re-verified today) — the caller-side owned-local escape shape.
- Upstream closed #6959 as "lifetime gotcha" (expected behavior), **not** a compiler fix.
- The prior verification only ran tests using **single-expression** escapes (`_lock_atomic(lk)[].fetch_add(...)` — pointer re-derived and consumed in one statement), which never hold the pointer in a local.

The WAR removal is nonetheless **safe** — but for a different reason: production escapes are **borrow-internal** (pointer derived from borrowed `self` within a method, owner kept alive by the caller frame). New evidence: `docs/dev/reproducers/probe_update_peak_shape.mojo` passes **5/5** on the exact `update_peak_cached` held-pointer shape.

## Files Modified
- `src/odyssey/testing/gradient_checker.mojo` (11 comment citations)
- `src/odyssey/tensor/any_tensor.mojo` (1 comment block)
- `docs/dev/mojo-1.0.0-regressions.md` (status tracker + classification table)
- `docs/dev/upstream-issue-drafts/fm1-return-move-uaf.md` (#6475 status)
- `docs/dev/reproducers/probe_update_peak_shape.mojo` (**new** — probe evidence)

## Verification
- Spinlock/memory-pool tests: PASS (both files)
- Gradient-checker tests (batch_norm, conv2d): PASS
- Tensor creation tests: PASS
- Escape-audit gate (`--raw-only`): 0 dangerous sites, exit 0
- Markdown lint: clean; Mojo format: clean; pre-commit: all green
